### PR TITLE
Introduce limited-time Max plan with unlimited credits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,8 +184,14 @@ db.version(N)
 
 User preferences use `localStorage` with service-level get/set wrappers. See [src/services/Settings.service.ts](src/services/Settings.service.ts).
 
+### Subscription Entitlement Changes
+
+- When a plan's allowance amounts change, preserve allowances already granted for the subscriber's current allowance window and apply the new amounts at the next allowance period unless the user explicitly requests an immediate change.
+- New subscriptions receive the current allowance configuration immediately. Subscription lifecycle changes such as cancellation or switching tiers continue to follow the active subscription state and are not deferred by this rule.
+
 ### Test Scope And Failure Mapping
 
+- Before creating a new test or materially expanding an existing test, discuss the proposed coverage with the user and get approval. Explain which behavior the test will protect, which test layer it belongs to, and why the test is valuable before writing it.
 - Treat tests as three explicit layers:
 - Type 1: pure logic/unit tests. These can mock freely and should not make UI behavior claims.
 - Type 2: service/state integration tests. Use these for app-owned rules and invariants without claiming real browser behavior. Good examples: deleting the correct chat record, editing message `content[231]` without shifting other indices, pruning the correct tail on regenerate, or building the correct final payload at the cloud-sync boundary.

--- a/src/index.html
+++ b/src/index.html
@@ -2085,33 +2085,35 @@ Your Max plan no longer has a monthly usage limit.</textarea
 									</div>
 								</div>
 								<div class="subscription-card-body">
-									<div class="subscription-price-stack">
-										<div class="subscription-price-line subscription-price-line-primary">
-											<span class="price-amount billing-only-monthly">$30</span>
-											<span class="price-amount billing-only-yearly">$25.83</span>
-											<span class="price-period billing-only-monthly">/month</span>
-											<span class="price-period billing-only-yearly">/month</span>
+									<div class="subscription-plan-summary">
+										<div class="subscription-price-stack">
+											<div class="subscription-price-line subscription-price-line-primary">
+												<span class="price-amount billing-only-monthly">$30</span>
+												<span class="price-amount billing-only-yearly">$25.83</span>
+												<span class="price-period billing-only-monthly">/month</span>
+												<span class="price-period billing-only-yearly">/month</span>
+											</div>
+											<div class="subscription-price-line subscription-price-line-secondary">
+												<span class="billing-only-monthly"
+													><span class="subscription-price-note">billed monthly</span></span
+												>
+												<span class="billing-only-yearly"
+													><span class="subscription-price-note"
+														>billed as $310 yearly</span
+													></span
+												>
+											</div>
 										</div>
-										<div class="subscription-price-line subscription-price-line-secondary">
-											<span class="billing-only-monthly"
-												><span class="subscription-price-note">billed monthly</span></span
-											>
-											<span class="billing-only-yearly"
-												><span class="subscription-price-note"
-													>billed as $310 yearly</span
-												></span
-											>
-										</div>
-									</div>
 
-									<div class="subscription-stat-grid">
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Mega Credits</span>
-											<strong>100 / month</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Image Credits</span>
-											<strong>50 / month</strong>
+										<div class="subscription-stat-grid">
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Mega Credits</span>
+												<strong>100 / month</strong>
+											</div>
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Image Credits</span>
+												<strong>50 / month</strong>
+											</div>
 										</div>
 									</div>
 
@@ -2168,33 +2170,35 @@ Your Max plan no longer has a monthly usage limit.</textarea
 									</div>
 								</div>
 								<div class="subscription-card-body">
-									<div class="subscription-price-stack">
-										<div class="subscription-price-line subscription-price-line-primary">
-											<span class="price-amount billing-only-monthly">$100</span>
-											<span class="price-amount billing-only-yearly">$91.67</span>
-											<span class="price-period billing-only-monthly">/month</span>
-											<span class="price-period billing-only-yearly">/month</span>
+									<div class="subscription-plan-summary">
+										<div class="subscription-price-stack">
+											<div class="subscription-price-line subscription-price-line-primary">
+												<span class="price-amount billing-only-monthly">$100</span>
+												<span class="price-amount billing-only-yearly">$91.67</span>
+												<span class="price-period billing-only-monthly">/month</span>
+												<span class="price-period billing-only-yearly">/month</span>
+											</div>
+											<div class="subscription-price-line subscription-price-line-secondary">
+												<span class="billing-only-monthly"
+													><span class="subscription-price-note">billed monthly</span></span
+												>
+												<span class="billing-only-yearly"
+													><span class="subscription-price-note"
+														>billed as $1100 yearly</span
+													></span
+												>
+											</div>
 										</div>
-										<div class="subscription-price-line subscription-price-line-secondary">
-											<span class="billing-only-monthly"
-												><span class="subscription-price-note">billed monthly</span></span
-											>
-											<span class="billing-only-yearly"
-												><span class="subscription-price-note"
-													>billed as $1100 yearly</span
-												></span
-											>
-										</div>
-									</div>
 
-									<div class="subscription-stat-grid">
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Mega Credits</span>
-											<strong>400 / month</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Image Credits</span>
-											<strong>500 / month</strong>
+										<div class="subscription-stat-grid">
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Mega Credits</span>
+												<strong>400 / month</strong>
+											</div>
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Image Credits</span>
+												<strong>500 / month</strong>
+											</div>
 										</div>
 									</div>
 
@@ -2232,6 +2236,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 								id="profile-max-card"
 								class="subscription-card subscription-card-max subscription-plan subscription-plan-max"
 							>
+								<div class="popular-badge popular-badge-limited">LIMITED EDITION</div>
 								<div class="subscription-card-header">
 									<div class="subscription-plan-heading">
 										<div class="tier-badge tier-badge-max">Max</div>
@@ -2242,33 +2247,35 @@ Your Max plan no longer has a monthly usage limit.</textarea
 									</div>
 								</div>
 								<div class="subscription-card-body">
-									<div class="subscription-price-stack">
-										<div class="subscription-price-line subscription-price-line-primary">
-											<span class="price-amount billing-only-monthly">$200</span>
-											<span class="price-amount billing-only-yearly">$183.33</span>
-											<span class="price-period billing-only-monthly">/month</span>
-											<span class="price-period billing-only-yearly">/month</span>
+									<div class="subscription-plan-summary">
+										<div class="subscription-price-stack">
+											<div class="subscription-price-line subscription-price-line-primary">
+												<span class="price-amount billing-only-monthly">$200</span>
+												<span class="price-amount billing-only-yearly">$183.33</span>
+												<span class="price-period billing-only-monthly">/month</span>
+												<span class="price-period billing-only-yearly">/month</span>
+											</div>
+											<div class="subscription-price-line subscription-price-line-secondary">
+												<span class="billing-only-monthly"
+													><span class="subscription-price-note">billed monthly</span></span
+												>
+												<span class="billing-only-yearly"
+													><span class="subscription-price-note"
+														>billed as $2200 yearly</span
+													></span
+												>
+											</div>
 										</div>
-										<div class="subscription-price-line subscription-price-line-secondary">
-											<span class="billing-only-monthly"
-												><span class="subscription-price-note">billed monthly</span></span
-											>
-											<span class="billing-only-yearly"
-												><span class="subscription-price-note"
-													>billed as $2200 yearly</span
-												></span
-											>
-										</div>
-									</div>
 
-									<div class="subscription-stat-grid">
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Mega Credits</span>
-											<strong>Unlimited</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Image Credits</span>
-											<strong>Unlimited</strong>
+										<div class="subscription-stat-grid">
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Mega Credits</span>
+												<strong>Unlimited</strong>
+											</div>
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Image Credits</span>
+												<strong>Unlimited</strong>
+											</div>
 										</div>
 									</div>
 
@@ -2292,6 +2299,14 @@ Your Max plan no longer has a monthly usage limit.</textarea
 											><span class="feature-text"
 												>Unlimited access to Claude Opus, GPT SOL, and more</span
 											>
+										</li>
+										<li class="feature-item feature-item-warning">
+											<span class="feature-icon">!</span
+											><span class="feature-text">Going away soon</span>
+										</li>
+										<li class="feature-item feature-item-warning">
+											<span class="feature-icon">!</span
+											><span class="feature-text">Buy now to lock this price forever</span>
 										</li>
 									</ul>
 								</div>

--- a/src/index.html
+++ b/src/index.html
@@ -2089,7 +2089,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										<div class="subscription-price-stack">
 											<div class="subscription-price-line subscription-price-line-primary">
 												<span class="price-amount billing-only-monthly">$30</span>
-												<span class="price-amount billing-only-yearly">$25.83</span>
+												<span class="price-amount billing-only-yearly">$26</span>
 												<span class="price-period billing-only-monthly">/month</span>
 												<span class="price-period billing-only-yearly">/month</span>
 											</div>
@@ -2174,7 +2174,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										<div class="subscription-price-stack">
 											<div class="subscription-price-line subscription-price-line-primary">
 												<span class="price-amount billing-only-monthly">$100</span>
-												<span class="price-amount billing-only-yearly">$91.67</span>
+												<span class="price-amount billing-only-yearly">$92</span>
 												<span class="price-period billing-only-monthly">/month</span>
 												<span class="price-period billing-only-yearly">/month</span>
 											</div>
@@ -2251,7 +2251,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										<div class="subscription-price-stack">
 											<div class="subscription-price-line subscription-price-line-primary">
 												<span class="price-amount billing-only-monthly">$200</span>
-												<span class="price-amount billing-only-yearly">$183.33</span>
+												<span class="price-amount billing-only-yearly">$183</span>
 												<span class="price-period billing-only-monthly">/month</span>
 												<span class="price-period billing-only-yearly">/month</span>
 											</div>

--- a/src/index.html
+++ b/src/index.html
@@ -2197,7 +2197,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 											</div>
 											<div class="subscription-stat">
 												<span class="subscription-stat-label">Image Credits</span>
-												<strong>500 / month</strong>
+												<strong>200 / month</strong>
 											</div>
 										</div>
 									</div>
@@ -2302,11 +2302,21 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										</li>
 										<li class="feature-item feature-item-warning">
 											<span class="feature-icon">!</span
-											><span class="feature-text">Going away soon</span>
+											><span class="feature-text"
+												>Available to new subscribers for a limited time</span
+											>
 										</li>
 										<li class="feature-item feature-item-warning">
 											<span class="feature-icon">!</span
-											><span class="feature-text">Buy now to lock this price forever</span>
+											><span class="feature-text"
+												>Keep Max and this price while continuously subscribed</span
+											>
+										</li>
+										<li class="feature-item feature-item-warning">
+											<span class="feature-icon">!</span
+											><span class="feature-text"
+												>Cancel or switch plans, and Max won't be available again</span
+											>
 										</li>
 									</ul>
 								</div>

--- a/src/services/Supabase.service.ts
+++ b/src/services/Supabase.service.ts
@@ -457,10 +457,6 @@ export function getSubscriptionTier(sub: UserSubscription | null): SubscriptionT
 		return "free";
 	}
 	switch (sub.price_id) {
-		case "price_1S0heGGiJrKwXclR69Ku7XEc": //legacy 29.99 oldstripe
-		case "price_1SDf2NGiJrKwXclRwDs7XOd0": //legacy oldstripe
-		case SubscriptionPriceIDsOld.MAX_MONTHLY:
-		case SubscriptionPriceIDsOld.MAX_YEARLY:
 		case SubscriptionPriceIDs.MAX_MONTHLY:
 		case SubscriptionPriceIDs.MAX_YEARLY:
 			return "max";

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2031,6 +2031,10 @@ form {
 		box-shadow 0.28s ease;
 }
 
+#form-subscription .subscription-card-free .subscription-price-stack {
+	width: 100%;
+}
+
 #form-subscription .subscription-price-line {
 	display: flex;
 	align-items: baseline;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1909,6 +1909,11 @@ form {
 	z-index: 2;
 }
 
+#form-subscription .popular-badge-limited {
+	background: linear-gradient(135deg, #b91c1c, #ef4444);
+	box-shadow: 0 10px 24px rgba(185, 28, 28, 0.26);
+}
+
 #form-subscription .subscription-card-header {
 	display: flex;
 	flex-direction: column;
@@ -2001,12 +2006,20 @@ form {
 	margin-inline: -1.35rem;
 }
 
+#form-subscription .subscription-plan-summary {
+	display: grid;
+	grid-template-columns: minmax(0, 1.25fr) minmax(8rem, 0.75fr);
+	align-items: stretch;
+	gap: 0.65rem;
+	width: 100%;
+}
+
 #form-subscription .subscription-price-stack {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	gap: 0.5rem;
-	width: 100%;
+	width: auto;
 	min-height: 6.7rem;
 	padding: 1rem;
 	border-radius: 1.2rem;
@@ -2071,17 +2084,17 @@ form {
 
 #form-subscription .subscription-stat-grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	width: 100%;
-	gap: 0.65rem;
+	grid-template-columns: minmax(0, 1fr);
+	min-width: 0;
+	gap: 0.55rem;
 }
 
 #form-subscription .subscription-stat {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	gap: 0.5rem;
-	padding: 0.9rem 0.85rem;
+	gap: 0.35rem;
+	padding: 0.7rem 0.75rem;
 	border-radius: 1rem;
 	background: rgba(255, 255, 255, 0.06);
 	border: 1px solid rgba(148, 163, 184, 0.12);
@@ -2160,6 +2173,18 @@ form {
 
 #form-subscription .feature-item-inherited .feature-icon {
 	display: none;
+}
+
+#form-subscription .feature-item-warning {
+	background: var(--warning-bg, rgba(255, 176, 59, 0.15));
+	border-color: var(--warning-border, rgba(255, 176, 59, 0.3));
+	color: var(--warning-fg, #ffb03b);
+}
+
+#form-subscription .feature-item-warning .feature-icon {
+	background: var(--warning-icon, #ffb03b);
+	box-shadow: none;
+	color: #1f2937;
 }
 
 #form-subscription .feature-item .feature-icon {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1952,7 +1952,7 @@ form {
 }
 
 #form-subscription .tier-badge-max {
-	background: linear-gradient(135deg, #0f172a, #475569);
+	background: linear-gradient(135deg, #e2e8f0, #94a3b8);
 	-webkit-background-clip: text;
 	-webkit-text-fill-color: transparent;
 	background-clip: text;
@@ -2015,9 +2015,7 @@ form {
 }
 
 #form-subscription .subscription-price-stack {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
+	display: grid;
 	gap: 0.5rem;
 	width: auto;
 	min-height: 6.7rem;
@@ -2033,6 +2031,39 @@ form {
 
 #form-subscription .subscription-card-free .subscription-price-stack {
 	width: 100%;
+	align-items: flex-start;
+	justify-items: start;
+	text-align: left;
+}
+
+#form-subscription .subscription-plan:not(.subscription-card-free) .subscription-price-stack {
+	align-items: center;
+	justify-items: center;
+	text-align: center;
+}
+
+#form-subscription .subscription-price-line-primary {
+	grid-row: 2;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.15rem;
+}
+
+#form-subscription .subscription-price-line-secondary {
+	grid-row: 3;
+	align-self: end;
+	justify-content: center;
+	text-align: center;
+}
+
+#form-subscription .subscription-card-free .subscription-price-line-primary {
+	align-items: flex-start;
+}
+
+#form-subscription .subscription-card-free .subscription-price-line-secondary {
+	justify-content: flex-start;
+	text-align: left;
 }
 
 #form-subscription .subscription-price-line {
@@ -2282,12 +2313,12 @@ form {
 }
 
 #form-subscription .subscription-cta-max {
-	background: linear-gradient(135deg, #111827, #334155);
+	background: linear-gradient(135deg, #334155, #475569);
 	box-shadow: 0 14px 32px rgba(15, 23, 42, 0.28);
 }
 
 #form-subscription .subscription-cta-max:hover {
-	background: linear-gradient(135deg, #0f172a, #1e293b);
+	background: linear-gradient(135deg, #1e293b, #334155);
 	box-shadow: 0 18px 36px rgba(15, 23, 42, 0.34);
 }
 

--- a/src/types/Price.ts
+++ b/src/types/Price.ts
@@ -2,10 +2,7 @@
 export enum SubscriptionPriceIDsOld {
 	//PRO
 	PRO_MONTHLY = "price_1SDdbKGiJrKwXclR7hn7fF4s",
-	PRO_YEARLY = "price_1SDeIFGiJrKwXclRCNThnoXH",
-	//MAX
-	MAX_MONTHLY = "price_1SDf2NGiJrKwXclRwDs7XOd0",
-	MAX_YEARLY = "price_1SDf2rGiJrKwXclReGeg8fQo"
+	PRO_YEARLY = "price_1SDeIFGiJrKwXclRCNThnoXH"
 }
 //newstripe
 export enum SubscriptionPriceIDs {

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -26,6 +26,15 @@ test("keeps subscription plan cards within the pricing panel on mobile", async (
 	await firstCard.locator(".subscription-card-header").click();
 	await expect(firstCard).toHaveClass(/subscription-card-expanded/);
 	expect(await firstCard.evaluate((card) => getComputedStyle(card).padding)).toBe(collapsedPadding);
+	const freePriceFillsCard = await firstCard.locator(".subscription-price-stack").evaluate((price) => {
+		const card = price.closest<HTMLElement>(".subscription-card");
+		if (!card) throw new Error("Missing Free card");
+		const cardStyle = getComputedStyle(card);
+		const availableWidth =
+			card.clientWidth - Number.parseFloat(cardStyle.paddingLeft) - Number.parseFloat(cardStyle.paddingRight);
+		return price.getBoundingClientRect().width >= availableWidth - 1;
+	});
+	expect(freePriceFillsCard, "Free card price panel should fill the available width").toBe(true);
 
 	await firstCard.hover();
 	expect(await firstCard.evaluate((card) => getComputedStyle(card).transform)).toBe("none");
@@ -130,6 +139,17 @@ test("presents Max text and image generation as unlimited", async ({ page }) => 
 	await expect(stats.nth(1).locator(".subscription-stat-label")).toHaveText("Image Credits");
 	await expect(stats.nth(1).locator("strong")).toHaveText("Unlimited");
 	await expect(page.locator("#profile-max-card")).toContainText("Unlimited access to Claude Opus, GPT SOL, and more");
+});
+
+test("rounds yearly-equivalent subscription prices", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openSubscriptionOverlay(page);
+
+	await expect(page.locator("#profile-pro-card .price-amount.billing-only-yearly")).toHaveText("$26");
+	await expect(page.locator("#profile-pro-plus-card .price-amount.billing-only-yearly")).toHaveText("$92");
+	await expect(page.locator("#profile-max-card .price-amount.billing-only-yearly")).toHaveText("$183");
 });
 
 test("plans use their own close button instead of the overlay back bar", async ({ page }) => {

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -51,12 +51,20 @@ test("keeps subscription plan cards within the pricing panel on mobile", async (
 	expect(layout.hasHorizontalOverflow, "Subscription pricing should not overflow horizontally").toBe(false);
 });
 
-test("keeps the best-value badge compact and credit cards side by side on mobile", async ({ page }) => {
+test("marks Max as limited edition and keeps paid-plan summaries compact on mobile", async ({ page }) => {
 	await page.setViewportSize({ width: 496, height: 961 });
 	await stubExternalTraffic(page, []);
 	await seedLocalSettings(page);
 	await page.goto("/");
 	await openSubscriptionOverlay(page);
+
+	const maxCard = page.locator("#profile-max-card");
+	const limitedBadge = maxCard.locator(".popular-badge-limited");
+	await expect(limitedBadge).toHaveText("LIMITED EDITION");
+	await expect(limitedBadge).toHaveClass(/popular-badge/);
+	await expect(maxCard).toContainText("Going away soon");
+	await expect(maxCard).toContainText("Buy now to lock this price forever");
+	expect(await limitedBadge.evaluate((element) => getComputedStyle(element).backgroundImage)).toMatch(/185/);
 
 	const proPlusCard = page.locator("#profile-pro-plus-card");
 	const badge = proPlusCard.locator(".popular-badge");
@@ -70,10 +78,31 @@ test("keeps the best-value badge compact and credit cards side by side on mobile
 	expect(await badge.evaluate((element) => getComputedStyle(element).fontSize)).toBe(collapsedBadgeStyle.fontSize);
 	expect(await badge.evaluate((element) => getComputedStyle(element).padding)).toBe(collapsedBadgeStyle.padding);
 
-	const statColumns = await proPlusCard
-		.locator(".subscription-stat-grid")
-		.evaluate((element) => getComputedStyle(element).gridTemplateColumns.split(" ").length);
-	expect(statColumns, "Credit cards should remain side by side on mobile").toBe(2);
+	for (const cardId of ["profile-pro-card", "profile-pro-plus-card", "profile-max-card"]) {
+		const card = page.locator(`#${cardId}`);
+		if (cardId !== "profile-pro-plus-card") {
+			await card.locator(".subscription-card-header").click();
+		}
+		await expect(card).toHaveClass(/subscription-card-expanded/);
+
+		const summaryLayout = await card.locator(".subscription-plan-summary").evaluate((summary) => {
+			const price = summary.querySelector<HTMLElement>(".subscription-price-stack");
+			const stats = summary.querySelector<HTMLElement>(".subscription-stat-grid");
+			if (!price || !stats) throw new Error("Missing paid-plan summary elements");
+
+			const priceBounds = price.getBoundingClientRect();
+			const statsBounds = stats.getBoundingClientRect();
+			return {
+				priceBeforeStats: priceBounds.right <= statsBounds.left,
+				statColumns: getComputedStyle(stats).gridTemplateColumns.split(" ").length,
+				statRows: getComputedStyle(stats).gridTemplateRows.split(" ").length
+			};
+		});
+
+		expect(summaryLayout.priceBeforeStats, `${cardId} should place credits beside the price`).toBe(true);
+		expect(summaryLayout.statColumns, `${cardId} credits should use one column`).toBe(1);
+		expect(summaryLayout.statRows, `${cardId} credits should stack vertically`).toBe(2);
+	}
 });
 
 test("renders FAQ questions in one column at desktop widths", async ({ page }) => {

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -71,9 +71,9 @@ test("marks Max as limited edition and keeps paid-plan summaries compact on mobi
 	const limitedBadge = maxCard.locator(".popular-badge-limited");
 	await expect(limitedBadge).toHaveText("LIMITED EDITION");
 	await expect(limitedBadge).toHaveClass(/popular-badge/);
-	await expect(maxCard).toContainText("Going away soon");
-	await expect(maxCard).toContainText("Buy now to lock this price forever");
-	expect(await limitedBadge.evaluate((element) => getComputedStyle(element).backgroundImage)).toMatch(/185/);
+	await expect(maxCard).toContainText("Available to new subscribers for a limited time");
+	await expect(maxCard).toContainText("Keep Max and this price while continuously subscribed");
+	await expect(maxCard).toContainText("Cancel or switch plans, and Max won't be available again");
 
 	const proPlusCard = page.locator("#profile-pro-plus-card");
 	const badge = proPlusCard.locator(".popular-badge");
@@ -150,6 +150,76 @@ test("rounds yearly-equivalent subscription prices", async ({ page }) => {
 	await expect(page.locator("#profile-pro-card .price-amount.billing-only-yearly")).toHaveText("$26");
 	await expect(page.locator("#profile-pro-plus-card .price-amount.billing-only-yearly")).toHaveText("$92");
 	await expect(page.locator("#profile-max-card .price-amount.billing-only-yearly")).toHaveText("$183");
+});
+
+test("stacks and centers subscription price periods", async ({ page }) => {
+	await page.setViewportSize({ width: 1600, height: 1000 });
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openSubscriptionOverlay(page);
+
+	const priceLayouts = await page.evaluate(() => {
+		const visible = (element: Element): boolean => {
+			const style = getComputedStyle(element);
+			return style.display !== "none" && style.visibility !== "hidden";
+		};
+
+		return ["profile-free-card", "profile-pro-card", "profile-pro-plus-card", "profile-max-card"].map((cardId) => {
+			const card = document.getElementById(cardId);
+			const stack = card?.querySelector<HTMLElement>(".subscription-price-stack");
+			const primary = card?.querySelector<HTMLElement>(".subscription-price-line-primary");
+			const amount = primary
+				? Array.from(primary.querySelectorAll<HTMLElement>(".price-amount")).find(visible)
+				: undefined;
+			const period = primary
+				? Array.from(primary.querySelectorAll<HTMLElement>(".price-period")).find(visible)
+				: undefined;
+
+			if (!card || !stack || !primary || !amount || !period) {
+				throw new Error(`Missing price layout elements for ${cardId}`);
+			}
+
+			const stackBounds = stack.getBoundingClientRect();
+			const amountBounds = amount.getBoundingClientRect();
+			const periodBounds = period.getBoundingClientRect();
+			const groupLeft = Math.min(amountBounds.left, periodBounds.left);
+			const groupRight = Math.max(amountBounds.right, periodBounds.right);
+			const stackStyle = getComputedStyle(stack);
+			const primaryStyle = getComputedStyle(primary);
+
+			return {
+				cardId,
+				periodBelowAmount: periodBounds.top >= amountBounds.bottom - 1,
+				groupCenteredHorizontally:
+					Math.abs(groupLeft + (groupRight - groupLeft) / 2 - (stackBounds.left + stackBounds.width / 2)) <=
+					1,
+				stackAlignItems: stackStyle.alignItems,
+				stackJustifyItems: stackStyle.justifyItems,
+				stackTextAlign: stackStyle.textAlign,
+				primaryFlexDirection: primaryStyle.flexDirection
+			};
+		});
+	});
+
+	for (const layout of priceLayouts) {
+		expect(layout.periodBelowAmount, `${layout.cardId} should put /month below the price`).toBe(true);
+		expect(layout.primaryFlexDirection, `${layout.cardId} price period should be on its own line`).toBe("column");
+
+		if (layout.cardId === "profile-free-card") {
+			expect(layout.stackAlignItems).toBe("flex-start");
+			expect(layout.stackJustifyItems).toBe("start");
+			expect(layout.groupCenteredHorizontally).toBe(false);
+		} else {
+			expect(
+				layout.groupCenteredHorizontally,
+				`${layout.cardId} price group should be horizontally centered`
+			).toBe(true);
+			expect(layout.stackAlignItems).toBe("center");
+			expect(layout.stackJustifyItems).toBe("center");
+			expect(layout.stackTextAlign).toBe("center");
+		}
+	}
 });
 
 test("plans use their own close button instead of the overlay back bar", async ({ page }) => {


### PR DESCRIPTION
## Summary
- present Max as a limited-time plan with unlimited Mega and Image Credits
- clarify continuous-subscription grandfathering and loss of Max after cancellation or switching
- align Pro Plus to 400 Mega and 200 Image Credits per monthly allowance period
- remove obsolete Max price aliases and refine subscription pricing layout

## Validation
- npm run build
- npm run lint
- npm test (125 passed)
- npx playwright test tests/e2e/subscription/mobile-layout.spec.ts (7 passed)
- Prettier and git diff checks

## Test scope
Existing Playwright coverage verifies the live subscription presentation and Max unlimited behavior. A cloud-sync variant is not warranted because the changed UI and entitlement classification do not depend on Zodiac's sync restoration boundary.