### PR TITLE
Prepare v1.8.9 release

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1659,16 +1659,21 @@
 					<h1 id="header-version">What's New in</h1>
 					<ul id="changelog">
 						<li>
-							<b>New image models:</b> Qwen 2.0/Pro, Seedream 4.5/5.0 Pro, Nano Banana variants, and Grok
-							Imagine
+							<b>Limited-edition Max plan:</b> Subscribe during the availability window for unlimited Mega
+							and Image Credits, 1 TB encrypted cloud sync, and continued access at the same price while
+							continuously subscribed
 						</li>
 						<li>
-							<b>Improved LoRA handling:</b> Receive duplicate or unsupported upload feedback, with credit
-							estimates based on model compatibility
+							<b>Clearer plan allowances:</b> Pro includes 100 Mega and 50 Image Credits per month, while
+							Pro Plus includes 400 Mega and 200 Image Credits; yearly plans replenish monthly
 						</li>
 						<li>
-							<b>Image model updates:</b> Imagen 4 Ultra has been retired and Illustrious (Anime) is now
-							the default image model
+							<b>More relevant in-app updates:</b> Important account and product notices can now appear
+							only for the people they apply to
+						</li>
+						<li>
+							<b>More reliable LoRAs and composer:</b> Duplicate LoRAs are handled cleanly, and composer
+							actions remain accessible on narrow screens
 						</li>
 					</ul>
 				</div>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-	return "1.8.8";
+	return "1.8.9";
 }
 
 export function getSanitized(string: string) {


### PR DESCRIPTION
## Summary
- bump Zodiac to v1.8.9
- replace the in-app changelog with polished release notes for limited-edition Max, plan allowances, targeted updates, and LoRA/composer reliability
- prepare the existing v1.8.9 draft for final post-deployment publication

## Validation
- npm run build
- npm run lint
- npm test (125 passed)
- npx playwright test tests/e2e/subscription/mobile-layout.spec.ts (7 passed)
- Prettier and git diff checks

Release preparation only; excluded from generated changelog candidates.