### PR TITLE
Promote v1.8.9 to production

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,25 +5,27 @@ change-template: "- $TITLE (#$NUMBER)"
 change-title-escapes: "<*_&"
 
 categories:
+    - type: "pre-include"
+      when:
+          labels:
+              - feature
+              - enhancement
+              - bug
+    - type: "pre-exclude"
+      when:
+          labels:
+              - code improvement
+              - documentation
+              - skip-changelog
     - title: "Features"
-      labels:
-          - feature
+      when:
+          label: feature
     - title: "Improvements"
-      labels:
-          - enhancement
+      when:
+          label: enhancement
     - title: "Fixes"
-      labels:
-          - bug
-
-include-labels:
-    - feature
-    - enhancement
-    - bug
-
-exclude-labels:
-    - code improvement
-    - documentation
-    - skip-changelog
+      when:
+          label: bug
 
 template: |
     ## What's New

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: "v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+commitish: production
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: "<*_&"
+
+categories:
+    - title: "Features"
+      labels:
+          - feature
+    - title: "Improvements"
+      labels:
+          - enhancement
+    - title: "Fixes"
+      labels:
+          - bug
+
+include-labels:
+    - feature
+    - enhancement
+    - bug
+
+exclude-labels:
+    - code improvement
+    - documentation
+    - skip-changelog
+
+template: |
+    ## What's New
+
+    $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,5 @@
 name-template: "v$NEXT_PATCH_VERSION"
 tag-template: "v$NEXT_PATCH_VERSION"
-commitish: production
 change-template: "- $TITLE (#$NUMBER)"
 change-title-escapes: "<*_&"
 

--- a/.github/scripts/validate-release-label.mjs
+++ b/.github/scripts/validate-release-label.mjs
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import process from "node:process";
+
+const classificationLabels = new Set([
+	"feature",
+	"enhancement",
+	"bug",
+	"code improvement",
+	"documentation",
+	"skip-changelog"
+]);
+
+const eventPath = process.env.GITHUB_EVENT_PATH;
+if (!eventPath) {
+	throw new Error("GITHUB_EVENT_PATH is required to validate pull request labels.");
+}
+
+const event = JSON.parse(readFileSync(eventPath, "utf8"));
+const pullRequestLabels = event.pull_request?.labels?.map((label) => label.name) ?? [];
+const classifications = pullRequestLabels.filter((label) => classificationLabels.has(label));
+
+if (classifications.length !== 1) {
+	process.stderr.write(
+		`Pull requests must have exactly one release classification label. Found ${classifications.length}: ${
+			classifications.join(", ") || "none"
+		}. Choose one of: ${[...classificationLabels].join(", ")}.\n`
+	);
+	process.exit(1);
+}
+
+process.stdout.write(`Release classification: ${classifications[0]}\n`);

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -5,6 +5,12 @@ on:
         branches:
             - main
             - production
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - labeled
+            - unlabeled
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -4,6 +4,7 @@ on:
     pull_request:
         branches:
             - main
+            - production
     workflow_dispatch:
 
 jobs:
@@ -13,6 +14,10 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
+
+            - name: Validate release classification
+              if: github.event_name == 'pull_request' && github.base_ref == 'main'
+              run: node .github/scripts/validate-release-label.mjs
 
             - name: Setup Node.js
               uses: actions/setup-node@v6

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+
+permissions:
+    contents: write
+    pull-requests: read
+
+jobs:
+    update-release-draft:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Update draft release
+              uses: release-drafter/release-drafter@v7
+              with:
+                  config-name: release-drafter.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,19 @@ npm run sync-db-types  # Sync Supabase types to src/types/database.types.ts
 
 ### Branching and deployment flow
 
-- Production deploys are published from a dedicated release branch because Cloudflare Pages is configured to deploy a specific branch for releases.
+- Cloudflare Pages production deployments are pinned to the permanent `production` branch.
 - `main` is the ongoing development branch.
-- A release branch is created from `main` after the intended features/fixes have already been merged there.
-- Release-only preparation happens on that release branch first.
-- After the release is deployed, the release branch must be backmerged into `main` so `main` also contains the final version string and in-app changelog for that release.
+- Feature and fix pull requests merge into `main`; do not commit feature work directly to `production`.
+- A temporary `release/vX.Y.Z` branch is created from `main` for the version bump and other release-only preparation. Build the in-app changelog from the current draft GitHub Release, polishing and combining its entries into user-facing copy.
+- Merge the prepared release branch back into `main` with the `skip-changelog` label on the PR, then promote `main` to `production` through a second pull request.
+- Cloudflare deploys the merge into `production`. No release backmerge is needed because release preparation entered `main` before promotion.
+
+### Pull request release classification
+
+- Every pull request targeting `main` must have exactly one release classification label. The merge gate enforces this rule. Promotion pull requests targeting `production` still run the full merge gate but do not need a release classification.
+- Use `feature`, `enhancement`, or `bug` for user-facing changes. Write those pull request titles as concise release-note candidates because Release Drafter uses them directly.
+- Use `code improvement` for internal refactors, `documentation` for documentation-only work, and `skip-changelog` for release preparation or other administrative changes targeting `main`. These labels are excluded from user-facing release notes.
+- Release Drafter runs after merges into `main` and continuously maintains the next draft GitHub Release from included pull requests. The draft targets `production` so publishing it after deployment tags the deployed branch.
 
 ### Pro request edge function slots
 
@@ -54,16 +62,17 @@ npm run sync-db-types  # Sync Supabase types to src/types/database.types.ts
 - `handle-pro-request` and `handle-pro-request-x` are equivalent rotating production slots. The currently released frontend points at one slot, while the other slot is available for the next synced frontend/backend release.
 - Only change the committed `PRO_REQUEST_FUNCTION_NAME` target as part of a new release workflow. Do not change the production target for ordinary feature work, fixes, local testing, or short-lived validation.
 - When a frontend/backend sync release is required, deploy the backend update to the production slot that the currently released frontend is not using, update `PRO_REQUEST_FUNCTION_NAME` to point the new frontend bundle at that slot, then deploy the frontend. This keeps old loaded clients on the old function and new clients on the new function.
-- Use `handle-pro-request-test` for quick backend iteration and local/manual validation. Point `PRO_REQUEST_FUNCTION_NAME` at the test slot only for local test builds or short-lived validation branches; do not leave production release branches pointed at the test slot.
+- Use `handle-pro-request-test` for quick backend iteration and local/manual validation. Point `PRO_REQUEST_FUNCTION_NAME` at the test slot only for local test builds or short-lived validation branches; do not promote a release to `production` while it points at the test slot.
 - Before changing the production target, verify every premium caller uses `PRO_REQUEST_ENDPOINT` rather than hardcoding a function URL.
 
 ### Preparing a new release
 
-- Identify the last release backmerge commit on `main`, then inspect all mainline commits after that point up to `HEAD`.
-- Use those commits to determine what actually shipped in the new release.
+- Open the continuously maintained draft GitHub Release before creating the release branch. Its categorized entries are the release-note candidates collected since the previous published release.
+- Create `release/vX.Y.Z` from `main`, then polish the draft entries into the final user-facing copy. Combine related pull requests and remove implementation detail rather than reconstructing the release from commit history.
 - Update the user-facing changelog in [src/index.html](src/index.html) under the `#whats-new` section.
 - Update the version string in [src/utils/helpers.ts](src/utils/helpers.ts) so the badge and changelog header display the new version.
-- Keep the release branch and deployed artifact aligned before any tag is created.
+- Update the draft GitHub Release to mirror the final in-app changelog.
+- Merge the release branch into `main`, promote `main` to `production`, and verify the Cloudflare deployment before publishing the draft.
 
 ### How to build the changelog well
 
@@ -76,17 +85,15 @@ npm run sync-db-types  # Sync Supabase types to src/types/database.types.ts
 
 ### Tagging guidance
 
-- Default release tags should point at the `main` merge commit created when the release branch is backmerged into `main`.
-- Do not create the release tag while the release PR is still open unless the user explicitly chooses to tag the release branch artifact instead.
-- If tags are meant to represent what is on `main`, create the tag after the release branch has been backmerged into `main`.
-- If tags are meant to represent the exact commit deployed by Cloudflare Pages, tag the release branch commit that was actually deployed.
-- Do not tag `main` before the backmerge if `main` does not yet contain the final release changelog/version bump.
+- Release tags must point at the exact commit deployed from `production`.
+- Do not create or publish the tag while either the release-preparation PR into `main` or the promotion PR into `production` is still open.
+- Verify the Cloudflare production deployment first, then publish the draft GitHub Release. Its `production` target creates the `vX.Y.Z` tag at the deployed branch head.
 
 ### Creating the GitHub Release
 
-- After the release tag has been pushed, create a GitHub Release from that tag so every shipped version has a published release entry on GitHub.
-- Create the release only once the tag exists, and respect the same constraints as the tagging step: do not publish the release while the release PR is still open unless the user explicitly chose to tag/release the deployed release-branch artifact instead.
-- Point the GitHub Release at the same tag chosen in the tagging step. By default that is the `vX.Y.Z` tag on the `main` backmerge commit; use the release-branch commit only if the user opted to tag the exact deployed artifact.
+- Release Drafter creates and maintains the upcoming GitHub Release as a draft; do not create a second release manually.
+- Publish the existing draft only after `main` has been promoted to `production` and the Cloudflare deployment has been verified.
+- Confirm that the draft targets `production` and that its version tag matches the version in [src/utils/helpers.ts](src/utils/helpers.ts).
 - Title the release to match that version tag (for example, `v1.8.5`).
 - The GitHub Release notes should mirror the in-app changelog from the `#whats-new` section in [src/index.html](src/index.html). Do not use raw PR titles or commit messages.
 - Reformat the changelog entries as a Markdown list under a `## What's New` heading, keeping the same user-facing, product-focused phrasing (bold the feature name, then the benefit):
@@ -98,7 +105,7 @@ npm run sync-db-types  # Sync Supabase types to src/types/database.types.ts
     - **More model choices:** New OpenRouter options are available, including expanded Gemini, Grok, Qwen, DeepSeek, and Inception models.
     ```
 
-- Create the release with `gh release create <tag> --title <tag> --notes "..."`, reusing the changelog copy already written for the in-app `#whats-new` section so the GitHub Release and the in-app changelog stay in sync.
+- Publish the prepared draft with `gh release edit <tag> --draft=false --latest`, after confirming its title, notes, and `production` target.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,8 +184,14 @@ db.version(N)
 
 User preferences use `localStorage` with service-level get/set wrappers. See [src/services/Settings.service.ts](src/services/Settings.service.ts).
 
+### Subscription Entitlement Changes
+
+- When a plan's allowance amounts change, preserve allowances already granted for the subscriber's current allowance window and apply the new amounts at the next allowance period unless the user explicitly requests an immediate change.
+- New subscriptions receive the current allowance configuration immediately. Subscription lifecycle changes such as cancellation or switching tiers continue to follow the active subscription state and are not deferred by this rule.
+
 ### Test Scope And Failure Mapping
 
+- Before creating a new test or materially expanding an existing test, discuss the proposed coverage with the user and get approval. Explain which behavior the test will protect, which test layer it belongs to, and why the test is valuable before writing it.
 - Treat tests as three explicit layers:
 - Type 1: pure logic/unit tests. These can mock freely and should not make UI behavior claims.
 - Type 2: service/state integration tests. Use these for app-owned rules and invariants without claiming real browser behavior. Good examples: deleting the correct chat record, editing message `content[231]` without shifting other indices, pruning the correct tail on regenerate, or building the correct final payload at the cloud-sync boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ npm run sync-db-types  # Sync Supabase types to src/types/database.types.ts
 - Every pull request targeting `main` must have exactly one release classification label. The merge gate enforces this rule. Promotion pull requests targeting `production` still run the full merge gate but do not need a release classification.
 - Use `feature`, `enhancement`, or `bug` for user-facing changes. Write those pull request titles as concise release-note candidates because Release Drafter uses them directly.
 - Use `code improvement` for internal refactors, `documentation` for documentation-only work, and `skip-changelog` for release preparation or other administrative changes targeting `main`. These labels are excluded from user-facing release notes.
-- Release Drafter runs after merges into `main` and continuously maintains the next draft GitHub Release from included pull requests. The draft targets `production` so publishing it after deployment tags the deployed branch.
+- Release Drafter runs after merges into `main` and continuously maintains the next draft GitHub Release from included pull requests. While it is a draft, it targets `main` so unreleased PRs can populate the release-note candidates. After deployment verification, retarget the draft to `production` before publishing so the tag is created from the deployed branch.
 
 ### Pro request edge function slots
 
@@ -71,8 +71,8 @@ npm run sync-db-types  # Sync Supabase types to src/types/database.types.ts
 - Create `release/vX.Y.Z` from `main`, then polish the draft entries into the final user-facing copy. Combine related pull requests and remove implementation detail rather than reconstructing the release from commit history.
 - Update the user-facing changelog in [src/index.html](src/index.html) under the `#whats-new` section.
 - Update the version string in [src/utils/helpers.ts](src/utils/helpers.ts) so the badge and changelog header display the new version.
-- Update the draft GitHub Release to mirror the final in-app changelog.
-- Merge the release branch into `main`, promote `main` to `production`, and verify the Cloudflare deployment before publishing the draft.
+- Merge the release branch into `main` with `skip-changelog`, then wait for Release Drafter's final `main` update before replacing its generated PR titles with the polished in-app changelog copy.
+- Promote `main` to `production`, verify the Cloudflare deployment, retarget the draft to `production`, and only then publish it.
 
 ### How to build the changelog well
 
@@ -87,13 +87,13 @@ npm run sync-db-types  # Sync Supabase types to src/types/database.types.ts
 
 - Release tags must point at the exact commit deployed from `production`.
 - Do not create or publish the tag while either the release-preparation PR into `main` or the promotion PR into `production` is still open.
-- Verify the Cloudflare production deployment first, then publish the draft GitHub Release. Its `production` target creates the `vX.Y.Z` tag at the deployed branch head.
+- Verify the Cloudflare production deployment first, then retarget and publish the draft GitHub Release. Its `production` target creates the `vX.Y.Z` tag at the deployed branch head.
 
 ### Creating the GitHub Release
 
 - Release Drafter creates and maintains the upcoming GitHub Release as a draft; do not create a second release manually.
 - Publish the existing draft only after `main` has been promoted to `production` and the Cloudflare deployment has been verified.
-- Confirm that the draft targets `production` and that its version tag matches the version in [src/utils/helpers.ts](src/utils/helpers.ts).
+- Retarget the draft from `main` to `production`, then confirm that its version tag matches the version in [src/utils/helpers.ts](src/utils/helpers.ts).
 - Title the release to match that version tag (for example, `v1.8.5`).
 - The GitHub Release notes should mirror the in-app changelog from the `#whats-new` section in [src/index.html](src/index.html). Do not use raw PR titles or commit messages.
 - Reformat the changelog entries as a Markdown list under a `## What's New` heading, keeping the same user-facing, product-focused phrasing (bold the feature name, then the benefit):
@@ -105,7 +105,7 @@ npm run sync-db-types  # Sync Supabase types to src/types/database.types.ts
     - **More model choices:** New OpenRouter options are available, including expanded Gemini, Grok, Qwen, DeepSeek, and Inception models.
     ```
 
-- Publish the prepared draft with `gh release edit <tag> --draft=false --latest`, after confirming its title, notes, and `production` target.
+- Retarget the prepared draft with `gh release edit <tag> --target production`, verify the deployed target commit, then publish it with `gh release edit <tag> --draft=false --latest`.
 
 ## Conventions
 

--- a/src/components/static/ApiKeyInput.component.ts
+++ b/src/components/static/ApiKeyInput.component.ts
@@ -16,6 +16,10 @@ const preferPremiumToggle = document.querySelector<HTMLDivElement>("#prefer-prem
 const preferPremiumCheckbox = document.querySelector<HTMLInputElement>("#preferPremiumEndpoint");
 const preferPremiumImageToggle = document.querySelector<HTMLDivElement>("#prefer-premium-image-endpoint-toggle");
 const preferPremiumImageCheckbox = document.querySelector<HTMLInputElement>("#preferPremiumImageEndpoint");
+const preferPremiumImageTitle = preferPremiumImageToggle?.querySelector<HTMLElement>(".settings-toggle-entry-title");
+const preferPremiumImageSubtitle = preferPremiumImageToggle?.querySelector<HTMLElement>(
+	".settings-toggle-entry-subtitle"
+);
 
 if (
 	!geminiApiKeyInput ||
@@ -25,7 +29,9 @@ if (
 	!preferPremiumToggle ||
 	!preferPremiumCheckbox ||
 	!preferPremiumImageToggle ||
-	!preferPremiumImageCheckbox
+	!preferPremiumImageCheckbox ||
+	!preferPremiumImageTitle ||
+	!preferPremiumImageSubtitle
 ) {
 	console.error("One or more API key input elements are missing.");
 	throw new Error("API key input initialization failed.");
@@ -39,6 +45,8 @@ const ensuredPreferPremiumToggle = preferPremiumToggle;
 const ensuredPreferPremiumCheckbox = preferPremiumCheckbox;
 const ensuredPreferPremiumImageToggle = preferPremiumImageToggle;
 const ensuredPreferPremiumImageCheckbox = preferPremiumImageCheckbox;
+const ensuredPreferPremiumImageTitle = preferPremiumImageTitle;
+const ensuredPreferPremiumImageSubtitle = preferPremiumImageSubtitle;
 let isPaidAccount = false;
 let hasObservedSyncedSettingsPull = false;
 
@@ -75,6 +83,14 @@ function rehydrateImagePremiumPreferenceFromStorage(): void {
 async function updateImagePremiumToggleVisibility(): Promise<void> {
 	const { type } = await isImageGenerationAvailable();
 	ensuredPreferPremiumImageToggle.classList.toggle("hidden", type !== "all");
+}
+
+function updateImagePremiumToggleCopy(tier: SubscriptionTier): void {
+	const isMax = tier === "max";
+	ensuredPreferPremiumImageTitle.textContent = isMax ? "Use Hosted Image Generation" : "Use Image Credits";
+	ensuredPreferPremiumImageSubtitle.textContent = isMax
+		? "Generate and edit images through Zodiac instead of your own API key."
+		: "Generate and edit images with your credits instead of your own API key.";
 }
 
 function persistDefaultPremiumPreferenceAfterSyncedSettingsPull(): void {
@@ -127,6 +143,7 @@ function attachValidation(args: {
 
 applyPremiumPreferenceFromStorage();
 applyImagePremiumPreferenceFromStorage();
+updateImagePremiumToggleCopy("free");
 void updateImagePremiumToggleVisibility();
 
 ensuredPreferPremiumCheckbox.addEventListener("change", () => {
@@ -149,8 +166,14 @@ ensuredPreferPremiumImageCheckbox.addEventListener("change", () => {
 	queuePremiumEndpointSettingsSync();
 });
 
-onAppEvent("auth-state-changed", () => void updateImagePremiumToggleVisibility());
-onAppEvent("subscription-updated", () => void updateImagePremiumToggleVisibility());
+onAppEvent("auth-state-changed", (event) => {
+	updateImagePremiumToggleCopy(getSubscriptionTier(event.detail.subscription ?? null));
+	void updateImagePremiumToggleVisibility();
+});
+onAppEvent("subscription-updated", (event) => {
+	updateImagePremiumToggleCopy(event.detail.tier);
+	void updateImagePremiumToggleVisibility();
+});
 onAppEvent("image-generation-record-refreshed", () => void updateImagePremiumToggleVisibility());
 
 onAppEvent("auth-state-changed", (event) => {

--- a/src/components/static/ApiKeyInput.component.ts
+++ b/src/components/static/ApiKeyInput.component.ts
@@ -69,11 +69,8 @@ function rehydrateImagePremiumPreferenceFromStorage(): void {
 }
 
 /**
- * The "use image credits" toggle is only meaningful for accounts that have image
- * credits. Every image model supports the EDGE (credit) route, so credit-holders are
- * the only users with a genuine credits-vs-BYOK choice; without credits there is a
- * single usable path and the toggle would be noise. Gated on credit access only
- * (isImageGenerationAvailable -> type "all"), independent of subscription tier.
+ * The hosted image toggle is only meaningful for accounts that can use the EDGE route.
+ * Without hosted access there is a single usable BYOK path, so the toggle would be noise.
  */
 async function updateImagePremiumToggleVisibility(): Promise<void> {
 	const { type } = await isImageGenerationAvailable();
@@ -226,8 +223,8 @@ export function hasOpenRouterApiKey(): boolean {
 }
 
 export function shouldPreferPremiumImageEndpoint(): boolean {
-	// A hidden toggle means the account has no image credits, so the edge route is
-	// unusable — treat the preference as off so image routing falls to BYOK.
+	// A hidden toggle means the account has no hosted image access, so treat the
+	// preference as off and let image routing fall back to BYOK.
 	if (ensuredPreferPremiumImageToggle.classList.contains("hidden")) {
 		return false;
 	}

--- a/src/components/static/CloudSync.component.ts
+++ b/src/components/static/CloudSync.component.ts
@@ -17,8 +17,7 @@ import * as personalityService from "../../services/Personality.service";
 import * as settingsService from "../../services/Settings.service";
 import { themeService } from "../../services/Theme.service";
 import * as loraService from "../../services/Lora.service";
-import { dispatchEmptyAppEvent } from "../../events";
-import { onAppEvent } from "../../events";
+import { dispatchAppEvent, dispatchEmptyAppEvent, onAppEvent } from "../../events";
 import type { SyncStatus } from "../../events";
 import { info, danger } from "../../services/Toast.service";
 import { confirmDialog, confirmDialogDanger } from "../../utils/helpers";
@@ -68,6 +67,7 @@ const btnSyncForgotPassword = document.querySelector<HTMLButtonElement>("#btn-sy
 
 /** Track current modal mode to handle confirm button correctly. */
 let modalMode: "setup" | "unlock" | "enable" | "final-download" = "setup";
+let syncStartupUserId: string | null = null;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -79,6 +79,12 @@ function showModal(el: HTMLElement | null) {
 function hideModal(el: HTMLElement | null) {
 	if (!el) return;
 	el.classList.add("hidden");
+}
+
+function settleSyncStartup(expectedUserId = syncStartupUserId): void {
+	if (!expectedUserId || syncStartupUserId !== expectedUserId) return;
+	dispatchAppEvent("sync-startup-settled", { userId: expectedUserId });
+	syncStartupUserId = null;
 }
 
 function showError(msg: string) {
@@ -222,6 +228,7 @@ btnSyncPromptLocal?.addEventListener("click", () => {
 	hideModal(syncPromptModal);
 	syncService.markSyncPromptSeen();
 	info({ title: "Data stays local", text: "You can enable cloud sync anytime from Settings → Data Management." });
+	settleSyncStartup();
 });
 
 // ── Encryption Password Modal ──────────────────────────────────────────────
@@ -316,6 +323,7 @@ btnSyncConfirm?.addEventListener(
 							text: "Migration complete. Local chat/persona data was deleted for maximum security; synced data now loads in-memory per session."
 						});
 						updateSettingsUI(true);
+						settleSyncStartup();
 					} else {
 						showError("Setup failed. Please try again.");
 					}
@@ -344,6 +352,7 @@ btnSyncConfirm?.addEventListener(
 							title: "Sync unlocked",
 							text: "Your synced data is available for this session (in-memory only)."
 						});
+						settleSyncStartup();
 					} else {
 						showError("Incorrect password. Please try again.");
 					}
@@ -403,6 +412,7 @@ btnSyncConfirm?.addEventListener(
 btnSyncSkip?.addEventListener("click", () => {
 	hideModal(syncModal);
 	resetModalFields();
+	settleSyncStartup();
 });
 
 // Forgot password escape hatch (visible in unlock and final-download modes)
@@ -429,6 +439,7 @@ btnSyncForgotPassword?.addEventListener(
 			} else {
 				danger({ title: "Error", text: "Failed to wipe cloud data. Please try again." });
 			}
+			settleSyncStartup();
 		})()
 );
 
@@ -592,51 +603,53 @@ onAppEvent(
 	"auth-state-changed",
 	(event) =>
 		void (async () => {
-			const { loggedIn, subscription } = event.detail;
+			const { loggedIn, subscription, session } = event.detail;
 
 			if (!loggedIn) {
 				// Hide sync section, reset state
+				syncStartupUserId = null;
 				cloudSyncSection?.classList.add("hidden");
 				cryptoService.clearCachedKey();
 				return;
 			}
 
+			const startupUserId = session?.user.id;
+			if (!startupUserId) return;
+			syncStartupUserId = startupUserId;
+
 			const tier = getSubscriptionTier(subscription ?? null);
 			const isPaid = tier === "pro" || tier === "pro_plus" || tier === "max";
 
-			if (isPaid && cloudSyncSection) {
-				cloudSyncSection.classList.remove("hidden");
-				syncUpgradeHint?.classList.add("hidden");
-				syncToggle?.removeAttribute("disabled");
+			try {
+				if (isPaid) {
+					cloudSyncSection?.classList.remove("hidden");
+					syncUpgradeHint?.classList.add("hidden");
+					syncToggle?.removeAttribute("disabled");
 
-				// Load current sync state
-				const prefs = await syncService.fetchSyncPreferences();
-				updateSettingsUI(prefs?.syncEnabled ?? false);
+					const prefs = await syncService.fetchSyncPreferences();
+					updateSettingsUI(prefs?.syncEnabled ?? false);
 
-				if (prefs?.syncEnabled) {
-					await syncService.fetchSyncQuota();
+					if (prefs?.syncEnabled) {
+						await syncService.fetchSyncQuota();
+					}
+				} else {
+					cloudSyncSection?.classList.remove("hidden");
+					syncUpgradeHint?.classList.remove("hidden");
+					syncToggle?.setAttribute("disabled", "true");
 				}
 
-				// During onboarding, cloud sync setup is handled inside onboarding flow.
-				// Avoid showing separate modals that occlude the onboarding UI.
+				// Onboarding owns its cloud-sync flow and remains the presentation blocker.
 				const onboardingCompleted = localStorage.getItem("onboardingCompleted") === "true";
 				if (!onboardingCompleted) {
+					settleSyncStartup(startupUserId);
 					return;
 				}
 
-				// Trigger unlock/setup prompt for paid users on login
-				await syncService.checkSyncOnLogin();
-			} else if (cloudSyncSection) {
-				cloudSyncSection.classList.remove("hidden");
-				syncUpgradeHint?.classList.remove("hidden");
-				syncToggle?.setAttribute("disabled", "true");
-
-				// Downgraded users may still have encrypted remote data.
-				// Offer one final restore-to-local flow and then revoke sync.
-				const onboardingCompleted = localStorage.getItem("onboardingCompleted") === "true";
-				if (onboardingCompleted) {
-					await syncService.checkSyncOnLogin();
-				}
+				const result = await syncService.checkSyncOnLogin();
+				if (result === "ready") settleSyncStartup(startupUserId);
+			} catch (error) {
+				console.error("Cloud sync startup check failed:", error);
+				settleSyncStartup(startupUserId);
 			}
 		})()
 );
@@ -670,6 +683,7 @@ onAppEvent(
 						title: "Cloud sync remains disabled",
 						text: "You can re-enable it anytime from Settings → Data Management."
 					});
+					settleSyncStartup();
 				}
 				return;
 			}
@@ -723,6 +737,8 @@ onAppEvent(
 					await chatsService.loadChat(currentChatId);
 				}
 			}
+
+			settleSyncStartup();
 		})()
 );
 

--- a/src/components/static/DebugAnnouncement.component.ts
+++ b/src/components/static/DebugAnnouncement.component.ts
@@ -1,0 +1,71 @@
+import * as overlayService from "../../services/Overlay.service";
+import * as toastService from "../../services/Toast.service";
+import { DEBUG_ANNOUNCEMENT_STORAGE_KEY, type Announcement, type AnnouncementAction } from "../../types/Announcement";
+
+const openButton = document.querySelector<HTMLButtonElement>("#btn-debug-announcement");
+const form = document.querySelector<HTMLFormElement>("#form-debug-announcement");
+const titleInput = document.querySelector<HTMLInputElement>("#debug-announcement-title");
+const bodyInput = document.querySelector<HTMLTextAreaElement>("#debug-announcement-body");
+const heroUrlInput = document.querySelector<HTMLInputElement>("#debug-announcement-hero-url");
+const heroAltInput = document.querySelector<HTMLInputElement>("#debug-announcement-hero-alt");
+const actionInput = document.querySelector<HTMLSelectElement>("#debug-announcement-action");
+const actionLabelInput = document.querySelector<HTMLInputElement>("#debug-announcement-action-label");
+const cancelButton = document.querySelector<HTMLButtonElement>("#btn-debug-announcement-cancel");
+
+if (
+	!openButton ||
+	!form ||
+	!titleInput ||
+	!bodyInput ||
+	!heroUrlInput ||
+	!heroAltInput ||
+	!actionInput ||
+	!actionLabelInput ||
+	!cancelButton
+) {
+	throw new Error("Missing debug announcement DOM elements");
+}
+
+const actionSelect = actionInput;
+const actionLabel = actionLabelInput;
+const isLocalhost = ["localhost", "127.0.0.1", "::1", "192.168.1.1"].includes(window.location.hostname);
+
+function updateActionLabelState(): void {
+	const hasAction = actionSelect.value === "dismiss" || actionSelect.value === "next";
+	actionLabel.disabled = !hasAction;
+	actionLabel.required = hasAction;
+}
+
+if (isLocalhost) {
+	openButton.addEventListener("click", () => {
+		overlayService.show("form-debug-announcement");
+		updateActionLabelState();
+		window.setTimeout(() => titleInput.focus(), 0);
+	});
+
+	actionSelect.addEventListener("change", updateActionLabelState);
+	cancelButton.addEventListener("click", () => overlayService.closeOverlay());
+
+	form.addEventListener("submit", (event) => {
+		event.preventDefault();
+		const action = (actionSelect.value || null) as AnnouncementAction | null;
+		const createdAt = Date.now();
+		const announcement: Announcement = {
+			id: `debug-announcement-${createdAt}`,
+			key: `debug-announcement-${createdAt}`,
+			title: titleInput.value.trim(),
+			body: bodyInput.value.trim(),
+			heroImageUrl: heroUrlInput.value.trim() || null,
+			heroImageAlt: heroAltInput.value.trim(),
+			actionLabel: action ? actionLabel.value.trim() : null,
+			action
+		};
+
+		localStorage.setItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY, JSON.stringify(announcement));
+		overlayService.closeOverlay();
+		toastService.info({
+			title: "Announcement preview saved",
+			text: "Refresh the app to display it."
+		});
+	});
+}

--- a/src/components/static/ImageCreditsLabel.component.ts
+++ b/src/components/static/ImageCreditsLabel.component.ts
@@ -152,7 +152,7 @@ function getSelectedChatModel(): string | null {
 }
 
 function selectedChatModelConsumesImageCredits(): boolean {
-	if (subscriptionTier === "free" || !shouldPreferPremiumEndpoint()) {
+	if (subscriptionTier === "free" || subscriptionTier === "max" || !shouldPreferPremiumEndpoint()) {
 		return false;
 	}
 
@@ -177,7 +177,7 @@ function getActiveImageRoute() {
 	const model = getActiveImageModel();
 	if (!model) return null;
 	return resolveImageModelRoute(model, shouldPreferPremiumImageEndpoint(), {
-		edgeCredits: Number(imageCredits ?? 0) > 0,
+		edgeCreditsAvailable: subscriptionTier === "max" || Number(imageCredits ?? 0) > 0,
 		geminiKey: hasGeminiApiKey(),
 		openRouterKey: hasOpenRouterApiKey()
 	});
@@ -193,6 +193,7 @@ function getCompatibleActiveLoraCount(): number {
 
 function getAllowanceMode(): AllowanceMode {
 	if (isImageEditingActive() || isImageModeActive()) {
+		if (subscriptionTier === "max") return null;
 		return getActiveImageRoute()?.route === "edge" ? "image" : null;
 	}
 

--- a/src/components/static/ProfilePanel.component.ts
+++ b/src/components/static/ProfilePanel.component.ts
@@ -1,3 +1,4 @@
+import type { SubscriptionTier } from "../../types/Supabase";
 import type { User } from "../../types/User";
 import * as supabaseService from "../../services/Supabase.service";
 import * as toastService from "../../services/Toast.service";
@@ -24,6 +25,7 @@ const resetPasswordButton = document.querySelector<HTMLButtonElement>("#btn-rese
 const changeEmailButton = document.querySelector<HTMLButtonElement>("#btn-change-email");
 let image: File | undefined;
 let isSavingProfile = false;
+let subscriptionTier: SubscriptionTier = "free";
 
 if (
 	!pfpChangeButton ||
@@ -70,15 +72,16 @@ async function updateProfile(user: User): Promise<void> {
 
 async function refreshSubscriptionAllowances(): Promise<void> {
 	const subscription = await supabaseService.getUserSubscription();
-	const tier = supabaseService.getSubscriptionTier(subscription);
+	subscriptionTier = supabaseService.getSubscriptionTier(subscription);
 	const imageGenerationRecord = await supabaseService.getImageGenerationRecord();
 
-	ensuredRemainingImageGenerations.textContent = (imageGenerationRecord?.remaining_image_generations ?? 0).toString();
+	ensuredRemainingImageGenerations.textContent =
+		subscriptionTier === "max" ? "Unlimited" : (imageGenerationRecord?.remaining_image_generations ?? 0).toString();
 
-	if (tier === "pro" || tier === "pro_plus") {
+	if (subscriptionTier === "pro" || subscriptionTier === "pro_plus") {
 		const megaCreditsRecord = await supabaseService.getMegaCreditsRecord();
 		ensuredRemainingMegaCredits.textContent = (megaCreditsRecord?.remaining_mega_credits ?? 0).toString();
-	} else if (tier === "max") {
+	} else if (subscriptionTier === "max") {
 		ensuredRemainingMegaCredits.textContent = "Unlimited";
 	} else {
 		ensuredRemainingMegaCredits.textContent = "—";
@@ -96,13 +99,15 @@ onAppEvent("profile-updated", (event) => {
 onAppEvent("image-generation-record-refreshed", (event) => {
 	const { imageGenerationRecord } = event.detail;
 	if (imageGenerationRecord) {
-		ensuredRemainingImageGenerations.textContent = (
-			imageGenerationRecord.remaining_image_generations ?? 0
-		).toString();
+		ensuredRemainingImageGenerations.textContent =
+			subscriptionTier === "max"
+				? "Unlimited"
+				: (imageGenerationRecord.remaining_image_generations ?? 0).toString();
 	}
 });
 
-onAppEvent("subscription-updated", () => {
+onAppEvent("subscription-updated", (event) => {
+	subscriptionTier = event.detail.tier;
 	refreshSubscriptionAllowances().catch((error) =>
 		console.error("Failed to refresh subscription allowances:", error)
 	);

--- a/src/components/static/TargetedAnnouncement.component.ts
+++ b/src/components/static/TargetedAnnouncement.component.ts
@@ -1,4 +1,4 @@
-import type { Announcement } from "../../types/Announcement";
+import { DEBUG_ANNOUNCEMENT_STORAGE_KEY, type Announcement } from "../../types/Announcement";
 import { onAppEvent } from "../../events";
 import { getEligibleAnnouncements, recordAnnouncementReceipt } from "../../services/Announcement.service";
 import * as overlayService from "../../services/Overlay.service";
@@ -42,8 +42,49 @@ let activeUserId: string | null = null;
 let loadingUserId: string | null = null;
 let loadedUserId: string | null = null;
 let currentAnnouncement: Announcement | null = null;
-let announcements: Announcement[] = [];
+let appReady = false;
 let presentationPaused = false;
+
+function readDebugAnnouncement(): Announcement | null {
+	const isLocalhost = ["localhost", "127.0.0.1", "::1", "192.168.1.1"].includes(window.location.hostname);
+	if (!isLocalhost) return null;
+
+	const stored = localStorage.getItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
+	if (!stored) return null;
+
+	try {
+		const value = JSON.parse(stored) as Partial<Announcement>;
+		const action = value.action === "dismiss" || value.action === "next" ? value.action : null;
+		if (
+			typeof value.id !== "string" ||
+			typeof value.key !== "string" ||
+			typeof value.title !== "string" ||
+			!value.title.trim() ||
+			typeof value.body !== "string" ||
+			!value.body.trim()
+		) {
+			throw new Error("Invalid debug announcement");
+		}
+
+		return {
+			id: value.id,
+			key: value.key,
+			title: value.title,
+			body: value.body,
+			heroImageUrl: typeof value.heroImageUrl === "string" && value.heroImageUrl ? value.heroImageUrl : null,
+			heroImageAlt: typeof value.heroImageAlt === "string" ? value.heroImageAlt : "",
+			actionLabel:
+				action && typeof value.actionLabel === "string" && value.actionLabel ? value.actionLabel : null,
+			action
+		};
+	} catch {
+		localStorage.removeItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
+		return null;
+	}
+}
+
+let debugAnnouncement = readDebugAnnouncement();
+let announcements: Announcement[] = debugAnnouncement ? [debugAnnouncement] : [];
 
 function canPresent(): boolean {
 	return overlay.classList.contains("hidden") && onboardingOverlay.classList.contains("hidden");
@@ -51,17 +92,19 @@ function canPresent(): boolean {
 
 function showNextAnnouncement(): void {
 	const modalAlreadyOpen = !modal.classList.contains("hidden");
+	const announcement = announcements[0];
+	const isDebugAnnouncement = announcement?.id === debugAnnouncement?.id;
 	if (
+		!appReady ||
 		presentationPaused ||
 		currentAnnouncement ||
-		!announcements.length ||
-		!activeUserId ||
+		!announcement ||
+		(!activeUserId && !isDebugAnnouncement) ||
 		(!modalAlreadyOpen && !canPresent())
 	) {
 		return;
 	}
 
-	const announcement = announcements[0];
 	currentAnnouncement = announcement;
 	title.textContent = announcement.title;
 	body.textContent = announcement.body;
@@ -86,7 +129,9 @@ function showNextAnnouncement(): void {
 		overlayService.show("targeted-announcement");
 		requestAnimationFrame(() => closeButton.focus());
 	}
-	void recordAnnouncementReceipt(activeUserId, announcement.id, "seen");
+	if (!isDebugAnnouncement && activeUserId) {
+		void recordAnnouncementReceipt(activeUserId, announcement.id, "seen");
+	}
 }
 
 function removeCurrentAnnouncement(): Announcement | null {
@@ -94,16 +139,22 @@ function removeCurrentAnnouncement(): Announcement | null {
 	if (!announcement) return null;
 
 	announcements = announcements.filter((candidate) => candidate.id !== announcement.id);
+	if (announcement.id === debugAnnouncement?.id) debugAnnouncement = null;
 	currentAnnouncement = null;
 	return announcement;
 }
 
 function dismissCurrentAnnouncement(actioned: boolean): void {
+	const isDebugAnnouncement = currentAnnouncement?.id === debugAnnouncement?.id;
 	const announcement = removeCurrentAnnouncement();
-	if (!announcement || !activeUserId) return;
+	if (!announcement) return;
 
 	presentationPaused = true;
-	void recordAnnouncementReceipt(activeUserId, announcement.id, actioned ? "actioned" : "dismissed");
+	if (isDebugAnnouncement) {
+		localStorage.removeItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
+	} else if (activeUserId) {
+		void recordAnnouncementReceipt(activeUserId, announcement.id, actioned ? "actioned" : "dismissed");
+	}
 	overlayService.closeOverlay();
 }
 
@@ -116,7 +167,12 @@ async function loadAnnouncements(userId: string): Promise<void> {
 	const eligibleAnnouncements = await getEligibleAnnouncements();
 	if (activeUserId !== userId) return;
 
-	announcements = eligibleAnnouncements;
+	announcements = debugAnnouncement
+		? [
+				debugAnnouncement,
+				...eligibleAnnouncements.filter((announcement) => announcement.id !== debugAnnouncement?.id)
+			]
+		: eligibleAnnouncements;
 	loadedUserId = userId;
 	loadingUserId = null;
 	showNextAnnouncement();
@@ -126,13 +182,18 @@ closeButton.addEventListener("click", () => dismissCurrentAnnouncement(false));
 
 actionButton.addEventListener("click", () => {
 	const announcement = currentAnnouncement;
-	if (!announcement || !activeUserId) return;
+	if (!announcement) return;
 
 	const action = announcement.action;
+	const isDebugAnnouncement = announcement.id === debugAnnouncement?.id;
 	const dismissedAnnouncement = removeCurrentAnnouncement();
 	if (!dismissedAnnouncement) return;
 
-	void recordAnnouncementReceipt(activeUserId, dismissedAnnouncement.id, "actioned");
+	if (isDebugAnnouncement) {
+		localStorage.removeItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
+	} else if (activeUserId) {
+		void recordAnnouncementReceipt(activeUserId, dismissedAnnouncement.id, "actioned");
+	}
 	if (action === "next" && announcements.length) {
 		showNextAnnouncement();
 		return;
@@ -163,17 +224,20 @@ onAppEvent("auth-state-changed", (event) => {
 	loadingUserId = null;
 	loadedUserId = null;
 	currentAnnouncement = null;
-	announcements = [];
-	presentationPaused = true;
+	announcements = debugAnnouncement ? [debugAnnouncement] : [];
+	presentationPaused = !debugAnnouncement;
+	showNextAnnouncement();
 });
 
-async function loadAnnouncementsForCurrentUser(): Promise<void> {
+async function initializeAnnouncements(): Promise<void> {
+	appReady = true;
+	showNextAnnouncement();
 	const user = await getCurrentUser();
 	if (user) void loadAnnouncements(user.id);
 }
 
 if (document.readyState === "complete") {
-	void loadAnnouncementsForCurrentUser();
+	void initializeAnnouncements();
 } else {
-	window.addEventListener("load", () => void loadAnnouncementsForCurrentUser(), { once: true });
+	window.addEventListener("load", () => void initializeAnnouncements(), { once: true });
 }

--- a/src/components/static/TargetedAnnouncement.component.ts
+++ b/src/components/static/TargetedAnnouncement.component.ts
@@ -1,0 +1,179 @@
+import type { Announcement } from "../../types/Announcement";
+import { onAppEvent } from "../../events";
+import { getEligibleAnnouncements, recordAnnouncementReceipt } from "../../services/Announcement.service";
+import * as overlayService from "../../services/Overlay.service";
+import { getCurrentUser } from "../../services/Supabase.service";
+
+const overlayElement = document.querySelector<HTMLElement>("#overlay");
+const onboardingOverlayElement = document.querySelector<HTMLElement>("#onboarding-overlay");
+const modalElement = document.querySelector<HTMLElement>("#targeted-announcement");
+const closeButtonElement = document.querySelector<HTMLButtonElement>("#targeted-announcement-close");
+const heroElement = document.querySelector<HTMLElement>("#targeted-announcement-hero");
+const heroImageElement = document.querySelector<HTMLImageElement>("#targeted-announcement-image");
+const titleElement = document.querySelector<HTMLElement>("#targeted-announcement-title");
+const bodyElement = document.querySelector<HTMLElement>("#targeted-announcement-body");
+const actionButtonElement = document.querySelector<HTMLButtonElement>("#targeted-announcement-action");
+
+if (
+	!overlayElement ||
+	!onboardingOverlayElement ||
+	!modalElement ||
+	!closeButtonElement ||
+	!heroElement ||
+	!heroImageElement ||
+	!titleElement ||
+	!bodyElement ||
+	!actionButtonElement
+) {
+	throw new Error("Missing targeted announcement DOM elements");
+}
+
+const overlay = overlayElement;
+const onboardingOverlay = onboardingOverlayElement;
+const modal = modalElement;
+const closeButton = closeButtonElement;
+const hero = heroElement;
+const heroImage = heroImageElement;
+const title = titleElement;
+const body = bodyElement;
+const actionButton = actionButtonElement;
+
+let activeUserId: string | null = null;
+let loadingUserId: string | null = null;
+let loadedUserId: string | null = null;
+let currentAnnouncement: Announcement | null = null;
+let announcements: Announcement[] = [];
+let presentationPaused = false;
+
+function canPresent(): boolean {
+	return overlay.classList.contains("hidden") && onboardingOverlay.classList.contains("hidden");
+}
+
+function showNextAnnouncement(): void {
+	const modalAlreadyOpen = !modal.classList.contains("hidden");
+	if (
+		presentationPaused ||
+		currentAnnouncement ||
+		!announcements.length ||
+		!activeUserId ||
+		(!modalAlreadyOpen && !canPresent())
+	) {
+		return;
+	}
+
+	const announcement = announcements[0];
+	currentAnnouncement = announcement;
+	title.textContent = announcement.title;
+	body.textContent = announcement.body;
+
+	hero.classList.add("hidden");
+	heroImage.removeAttribute("src");
+	heroImage.alt = announcement.heroImageAlt;
+	if (announcement.heroImageUrl) {
+		heroImage.onload = () => hero.classList.remove("hidden");
+		heroImage.onerror = () => hero.classList.add("hidden");
+		heroImage.src = announcement.heroImageUrl;
+	}
+
+	if (announcement.action && announcement.actionLabel) {
+		actionButton.textContent = announcement.actionLabel;
+		actionButton.classList.remove("hidden");
+	} else {
+		actionButton.classList.add("hidden");
+	}
+
+	if (!modalAlreadyOpen) {
+		overlayService.show("targeted-announcement");
+		requestAnimationFrame(() => closeButton.focus());
+	}
+	void recordAnnouncementReceipt(activeUserId, announcement.id, "seen");
+}
+
+function removeCurrentAnnouncement(): Announcement | null {
+	const announcement = currentAnnouncement;
+	if (!announcement) return null;
+
+	announcements = announcements.filter((candidate) => candidate.id !== announcement.id);
+	currentAnnouncement = null;
+	return announcement;
+}
+
+function dismissCurrentAnnouncement(actioned: boolean): void {
+	const announcement = removeCurrentAnnouncement();
+	if (!announcement || !activeUserId) return;
+
+	presentationPaused = true;
+	void recordAnnouncementReceipt(activeUserId, announcement.id, actioned ? "actioned" : "dismissed");
+	overlayService.closeOverlay();
+}
+
+async function loadAnnouncements(userId: string): Promise<void> {
+	if (loadingUserId === userId || loadedUserId === userId) return;
+
+	activeUserId = userId;
+	loadingUserId = userId;
+	presentationPaused = false;
+	const eligibleAnnouncements = await getEligibleAnnouncements();
+	if (activeUserId !== userId) return;
+
+	announcements = eligibleAnnouncements;
+	loadedUserId = userId;
+	loadingUserId = null;
+	showNextAnnouncement();
+}
+
+closeButton.addEventListener("click", () => dismissCurrentAnnouncement(false));
+
+actionButton.addEventListener("click", () => {
+	const announcement = currentAnnouncement;
+	if (!announcement || !activeUserId) return;
+
+	const action = announcement.action;
+	const dismissedAnnouncement = removeCurrentAnnouncement();
+	if (!dismissedAnnouncement) return;
+
+	void recordAnnouncementReceipt(activeUserId, dismissedAnnouncement.id, "actioned");
+	if (action === "next" && announcements.length) {
+		showNextAnnouncement();
+		return;
+	}
+
+	presentationPaused = true;
+	overlayService.closeOverlay();
+});
+
+document.addEventListener("keydown", (event) => {
+	if (event.key === "Escape" && !modal.classList.contains("hidden")) {
+		event.preventDefault();
+		dismissCurrentAnnouncement(false);
+	}
+});
+
+const overlayObserver = new MutationObserver(() => showNextAnnouncement());
+overlayObserver.observe(overlay, { attributes: true, attributeFilter: ["class"] });
+overlayObserver.observe(onboardingOverlay, { attributes: true, attributeFilter: ["class"] });
+
+onAppEvent("auth-state-changed", (event) => {
+	if (event.detail.loggedIn && event.detail.session) {
+		void loadAnnouncements(event.detail.session.user.id);
+		return;
+	}
+
+	activeUserId = null;
+	loadingUserId = null;
+	loadedUserId = null;
+	currentAnnouncement = null;
+	announcements = [];
+	presentationPaused = true;
+});
+
+async function loadAnnouncementsForCurrentUser(): Promise<void> {
+	const user = await getCurrentUser();
+	if (user) void loadAnnouncements(user.id);
+}
+
+if (document.readyState === "complete") {
+	void loadAnnouncementsForCurrentUser();
+} else {
+	window.addEventListener("load", () => void loadAnnouncementsForCurrentUser(), { once: true });
+}

--- a/src/components/static/TargetedAnnouncement.component.ts
+++ b/src/components/static/TargetedAnnouncement.component.ts
@@ -6,6 +6,7 @@ import { getCurrentUser } from "../../services/Supabase.service";
 
 const overlayElement = document.querySelector<HTMLElement>("#overlay");
 const onboardingOverlayElement = document.querySelector<HTMLElement>("#onboarding-overlay");
+const appDialogs = document.querySelectorAll<HTMLElement>("#main-container > .dialog");
 const modalElement = document.querySelector<HTMLElement>("#targeted-announcement");
 const closeButtonElement = document.querySelector<HTMLButtonElement>("#targeted-announcement-close");
 const heroElement = document.querySelector<HTMLElement>("#targeted-announcement-hero");
@@ -41,6 +42,7 @@ const actionButton = actionButtonElement;
 let activeUserId: string | null = null;
 let loadingUserId: string | null = null;
 let loadedUserId: string | null = null;
+let syncStartupSettledUserId: string | null = null;
 let currentAnnouncement: Announcement | null = null;
 let appReady = false;
 let presentationPaused = false;
@@ -87,7 +89,11 @@ let debugAnnouncement = readDebugAnnouncement();
 let announcements: Announcement[] = debugAnnouncement ? [debugAnnouncement] : [];
 
 function canPresent(): boolean {
-	return overlay.classList.contains("hidden") && onboardingOverlay.classList.contains("hidden");
+	return (
+		overlay.classList.contains("hidden") &&
+		onboardingOverlay.classList.contains("hidden") &&
+		Array.from(appDialogs).every((dialog) => dialog.classList.contains("hidden"))
+	);
 }
 
 function showNextAnnouncement(): void {
@@ -100,6 +106,7 @@ function showNextAnnouncement(): void {
 		currentAnnouncement ||
 		!announcement ||
 		(!activeUserId && !isDebugAnnouncement) ||
+		(activeUserId !== null && syncStartupSettledUserId !== activeUserId) ||
 		(!modalAlreadyOpen && !canPresent())
 	) {
 		return;
@@ -213,16 +220,26 @@ document.addEventListener("keydown", (event) => {
 const overlayObserver = new MutationObserver(() => showNextAnnouncement());
 overlayObserver.observe(overlay, { attributes: true, attributeFilter: ["class"] });
 overlayObserver.observe(onboardingOverlay, { attributes: true, attributeFilter: ["class"] });
+appDialogs.forEach((dialog) => overlayObserver.observe(dialog, { attributes: true, attributeFilter: ["class"] }));
+
+onAppEvent("sync-startup-settled", (event) => {
+	syncStartupSettledUserId = event.detail.userId;
+	showNextAnnouncement();
+});
 
 onAppEvent("auth-state-changed", (event) => {
 	if (event.detail.loggedIn && event.detail.session) {
-		void loadAnnouncements(event.detail.session.user.id);
+		const userId = event.detail.session.user.id;
+		if (syncStartupSettledUserId !== userId) syncStartupSettledUserId = null;
+		activeUserId = userId;
+		void loadAnnouncements(userId);
 		return;
 	}
 
 	activeUserId = null;
 	loadingUserId = null;
 	loadedUserId = null;
+	syncStartupSettledUserId = null;
 	currentAnnouncement = null;
 	announcements = debugAnnouncement ? [debugAnnouncement] : [];
 	presentationPaused = !debugAnnouncement;
@@ -230,10 +247,13 @@ onAppEvent("auth-state-changed", (event) => {
 });
 
 async function initializeAnnouncements(): Promise<void> {
-	appReady = true;
-	showNextAnnouncement();
 	const user = await getCurrentUser();
-	if (user) void loadAnnouncements(user.id);
+	appReady = true;
+	if (user) {
+		activeUserId = user.id;
+		void loadAnnouncements(user.id);
+	}
+	showNextAnnouncement();
 }
 
 if (document.readyState === "complete") {

--- a/src/components/static/TopUpImageCredits.component.ts
+++ b/src/components/static/TopUpImageCredits.component.ts
@@ -2,24 +2,46 @@ import * as overlayService from "../../services/Overlay.service";
 import { supabase } from "../../services/Supabase.service";
 import * as supabaseService from "../../services/Supabase.service";
 import * as toastService from "../../services/Toast.service";
+import { onAppEvent } from "../../events";
 
 const topUpButton = document.querySelector<HTMLButtonElement>("#btn-top-up-credits");
 const topUp10Button = document.querySelector<HTMLButtonElement>("#btn-top-up-10");
 const topUp30Button = document.querySelector<HTMLButtonElement>("#btn-top-up-30");
 const topUp70Button = document.querySelector<HTMLButtonElement>("#btn-top-up-70");
 
-//if no logged in user, hide the top up button
-const loggedUser = await supabaseService.getCurrentUser();
-
-if (!loggedUser) {
-	if (topUpButton) {
-		topUpButton.style.display = "none";
-	}
-}
 if (!topUpButton || !topUp10Button || !topUp30Button || !topUp70Button) {
 	console.error("One or more Top-Up buttons not found");
 	throw new Error("One or more Top-Up buttons not found");
 }
+
+let isLoggedIn = false;
+
+function setTopUpVisibility(tier: supabaseService.SubscriptionTier): void {
+	topUpButton!.classList.toggle("hidden", !isLoggedIn || tier === "max");
+}
+
+async function refreshTopUpVisibility(): Promise<void> {
+	const user = await supabaseService.getCurrentUser();
+	isLoggedIn = !!user;
+	if (!user) {
+		setTopUpVisibility("free");
+		return;
+	}
+
+	const subscription = await supabaseService.getUserSubscription();
+	setTopUpVisibility(supabaseService.getSubscriptionTier(subscription));
+}
+
+onAppEvent("auth-state-changed", (event) => {
+	isLoggedIn = event.detail.loggedIn;
+	setTopUpVisibility(supabaseService.getSubscriptionTier(event.detail.subscription ?? null));
+});
+
+onAppEvent("subscription-updated", (event) => {
+	setTopUpVisibility(event.detail.tier);
+});
+
+void refreshTopUpVisibility();
 
 topUpButton.addEventListener(
 	"click",

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -226,6 +226,10 @@ export interface SyncDataPulledDetail {
 	// No detail payload
 }
 
+export interface SyncStartupSettledDetail {
+	userId: string;
+}
+
 // ================================================================================
 // EVENT NAME CONSTANTS
 // ================================================================================
@@ -294,7 +298,8 @@ export const EventNames = {
 	SYNC_STATE_CHANGED: "sync-state-changed",
 	SYNC_QUOTA_UPDATED: "sync-quota-updated",
 	SYNC_SETUP_COMPLETE: "sync-setup-complete",
-	SYNC_DATA_PULLED: "sync-data-pulled"
+	SYNC_DATA_PULLED: "sync-data-pulled",
+	SYNC_STARTUP_SETTLED: "sync-startup-settled"
 } as const;
 
 export type EventName = (typeof EventNames)[keyof typeof EventNames];
@@ -372,6 +377,7 @@ export interface AppEventMap {
 	[EventNames.SYNC_QUOTA_UPDATED]: SyncQuotaUpdatedDetail;
 	[EventNames.SYNC_SETUP_COMPLETE]: SyncSetupCompleteDetail;
 	[EventNames.SYNC_DATA_PULLED]: SyncDataPulledDetail;
+	[EventNames.SYNC_STARTUP_SETTLED]: SyncStartupSettledDetail;
 }
 
 // ================================================================================

--- a/src/index.html
+++ b/src/index.html
@@ -417,11 +417,8 @@
 									</div>
 									<div id="prefer-premium-image-endpoint-toggle" class="settings-toggle-entry hidden">
 										<label class="settings-toggle-entry-label" for="preferPremiumImageEndpoint">
-											<span class="settings-toggle-entry-title">Use Hosted Image Generation</span>
-											<span class="settings-toggle-entry-subtitle"
-												>Generate and edit images through Zodiac instead of your own API
-												key.</span
-											>
+											<span class="settings-toggle-entry-title"></span>
+											<span class="settings-toggle-entry-subtitle"></span>
 										</label>
 										<input type="checkbox" id="preferPremiumImageEndpoint" checked />
 									</div>
@@ -1786,7 +1783,7 @@
 
 					<label for="debug-announcement-body">Body</label>
 					<textarea id="debug-announcement-body" rows="4" required>
-Your Max plan now includes unlimited text and image generation.</textarea
+Your Max plan no longer has a monthly usage limit.</textarea
 					>
 
 					<label for="debug-announcement-hero-url">Hero image URL</label>
@@ -1914,7 +1911,7 @@ Your Max plan now includes unlimited text and image generation.</textarea
 								</div>
 
 								<div class="subscription-row">
-									<span class="setting-label">Image generation</span>
+									<span class="setting-label">Image generation credits</span>
 									<span id="subscription-remaining-generations">—</span>
 								</div>
 								<div class="subscription-row">
@@ -2266,11 +2263,11 @@ Your Max plan now includes unlimited text and image generation.</textarea
 
 									<div class="subscription-stat-grid">
 										<div class="subscription-stat">
-											<span class="subscription-stat-label">Text Generation</span>
+											<span class="subscription-stat-label">Mega Credits</span>
 											<strong>Unlimited</strong>
 										</div>
 										<div class="subscription-stat">
-											<span class="subscription-stat-label">Image Generation</span>
+											<span class="subscription-stat-label">Image Credits</span>
 											<strong>Unlimited</strong>
 										</div>
 									</div>
@@ -2293,7 +2290,7 @@ Your Max plan now includes unlimited text and image generation.</textarea
 										<li class="feature-item">
 											<span class="feature-icon">✓</span
 											><span class="feature-text"
-												>Unlimited access to all hosted text and image models</span
+												>Unlimited access to Claude Opus, GPT SOL, and more</span
 											>
 										</li>
 									</ul>

--- a/src/index.html
+++ b/src/index.html
@@ -1673,6 +1673,38 @@
 					</ul>
 				</div>
 
+				<section
+					id="targeted-announcement"
+					class="targeted-announcement hidden"
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby="targeted-announcement-title"
+					tabindex="-1"
+				>
+					<button
+						id="targeted-announcement-close"
+						class="targeted-announcement-close material-symbols-outlined"
+						type="button"
+						aria-label="Dismiss announcement"
+					>
+						close
+					</button>
+					<div id="targeted-announcement-hero" class="targeted-announcement-hero hidden">
+						<img id="targeted-announcement-image" alt="" decoding="async" />
+					</div>
+					<div class="targeted-announcement-content">
+						<h1 id="targeted-announcement-title"></h1>
+						<p id="targeted-announcement-body"></p>
+						<div class="targeted-announcement-actions">
+							<button
+								id="targeted-announcement-action"
+								class="btn btn-primary hidden"
+								type="button"
+							></button>
+						</div>
+					</div>
+				</section>
+
 				<!-- Add Persona Modal -->
 				<div id="modal-add-persona" class="hidden">
 					<span class="material-symbols-outlined sync-modal-icon">person_add</span>

--- a/src/index.html
+++ b/src/index.html
@@ -417,9 +417,9 @@
 									</div>
 									<div id="prefer-premium-image-endpoint-toggle" class="settings-toggle-entry hidden">
 										<label class="settings-toggle-entry-label" for="preferPremiumImageEndpoint">
-											<span class="settings-toggle-entry-title">Use Image Credits</span>
+											<span class="settings-toggle-entry-title">Use Hosted Image Generation</span>
 											<span class="settings-toggle-entry-subtitle"
-												>Generate and edit images with your credits instead of your own API
+												>Generate and edit images through Zodiac instead of your own API
 												key.</span
 											>
 										</label>
@@ -1786,7 +1786,7 @@
 
 					<label for="debug-announcement-body">Body</label>
 					<textarea id="debug-announcement-body" rows="4" required>
-Your Max plan no longer has a monthly usage limit.</textarea
+Your Max plan now includes unlimited text and image generation.</textarea
 					>
 
 					<label for="debug-announcement-hero-url">Hero image URL</label>
@@ -1914,7 +1914,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 								</div>
 
 								<div class="subscription-row">
-									<span class="setting-label">Image generation credits</span>
+									<span class="setting-label">Image generation</span>
 									<span id="subscription-remaining-generations">—</span>
 								</div>
 								<div class="subscription-row">
@@ -2266,12 +2266,12 @@ Your Max plan no longer has a monthly usage limit.</textarea
 
 									<div class="subscription-stat-grid">
 										<div class="subscription-stat">
-											<span class="subscription-stat-label">Mega Credits</span>
+											<span class="subscription-stat-label">Text Generation</span>
 											<strong>Unlimited</strong>
 										</div>
 										<div class="subscription-stat">
-											<span class="subscription-stat-label">Image Credits</span>
-											<strong>1000 / month</strong>
+											<span class="subscription-stat-label">Image Generation</span>
+											<strong>Unlimited</strong>
 										</div>
 									</div>
 
@@ -2293,7 +2293,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										<li class="feature-item">
 											<span class="feature-icon">✓</span
 											><span class="feature-text"
-												>Unlimited access to Claude Opus 4.8 and GPT-5.5</span
+												>Unlimited access to all hosted text and image models</span
 											>
 										</li>
 									</ul>
@@ -2329,8 +2329,9 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										<summary>How do Image Credits work?</summary>
 										<p>
 											Image Credits power Zodiac's dedicated image generation and editing models.
-											Each completed EDGE-routed image request consumes credits, while requests
-											using your own Google or OpenRouter API key do not.
+											Pro and Pro Plus include a monthly allowance, while Max includes unlimited
+											hosted image generation and editing. Requests using your own Google or
+											OpenRouter API key do not use credits.
 										</p>
 									</details>
 

--- a/src/index.html
+++ b/src/index.html
@@ -1124,6 +1124,9 @@
 									Open Subscription Options
 								</button>
 								<button class="btn btn-primary" id="btn-debug-onboarding">Test Onboarding</button>
+								<button class="btn btn-primary" id="btn-debug-announcement">
+									Compose Announcement Preview
+								</button>
 							</div>
 						</div>
 					</div>
@@ -1773,6 +1776,51 @@
 						</button>
 					</div>
 				</div>
+
+				<form id="form-debug-announcement" class="debug-announcement-form hidden">
+					<h1>Announcement Preview</h1>
+					<p class="overlay-description">Save a one-time announcement to display after the next refresh.</p>
+
+					<label for="debug-announcement-title">Title</label>
+					<input id="debug-announcement-title" type="text" value="Max is now unlimited" required />
+
+					<label for="debug-announcement-body">Body</label>
+					<textarea id="debug-announcement-body" rows="4" required>
+Your Max plan no longer has a monthly usage limit.</textarea
+					>
+
+					<label for="debug-announcement-hero-url">Hero image URL</label>
+					<input
+						id="debug-announcement-hero-url"
+						type="url"
+						placeholder="https://example.com/announcement.webp"
+					/>
+
+					<label for="debug-announcement-hero-alt">Hero image alt text</label>
+					<input id="debug-announcement-hero-alt" type="text" placeholder="Describe the image" />
+
+					<div class="debug-announcement-action-fields">
+						<div>
+							<label for="debug-announcement-action">Action</label>
+							<select id="debug-announcement-action">
+								<option value="">No action</option>
+								<option value="dismiss" selected>Dismiss</option>
+								<option value="next">Next</option>
+							</select>
+						</div>
+						<div>
+							<label for="debug-announcement-action-label">Action label</label>
+							<input id="debug-announcement-action-label" type="text" value="Got it" required />
+						</div>
+					</div>
+
+					<div class="overlay-actions">
+						<button id="btn-debug-announcement-cancel" class="btn btn-secondary" type="button">
+							Cancel
+						</button>
+						<button class="btn btn-primary" type="submit">Save for next refresh</button>
+					</div>
+				</form>
 
 				<div id="login-register-tabs" class="hidden">
 					<div class="navbar" data-target-id="login-register-container">

--- a/src/index.html
+++ b/src/index.html
@@ -2085,33 +2085,35 @@ Your Max plan no longer has a monthly usage limit.</textarea
 									</div>
 								</div>
 								<div class="subscription-card-body">
-									<div class="subscription-price-stack">
-										<div class="subscription-price-line subscription-price-line-primary">
-											<span class="price-amount billing-only-monthly">$30</span>
-											<span class="price-amount billing-only-yearly">$25.83</span>
-											<span class="price-period billing-only-monthly">/month</span>
-											<span class="price-period billing-only-yearly">/month</span>
+									<div class="subscription-plan-summary">
+										<div class="subscription-price-stack">
+											<div class="subscription-price-line subscription-price-line-primary">
+												<span class="price-amount billing-only-monthly">$30</span>
+												<span class="price-amount billing-only-yearly">$25.83</span>
+												<span class="price-period billing-only-monthly">/month</span>
+												<span class="price-period billing-only-yearly">/month</span>
+											</div>
+											<div class="subscription-price-line subscription-price-line-secondary">
+												<span class="billing-only-monthly"
+													><span class="subscription-price-note">billed monthly</span></span
+												>
+												<span class="billing-only-yearly"
+													><span class="subscription-price-note"
+														>billed as $310 yearly</span
+													></span
+												>
+											</div>
 										</div>
-										<div class="subscription-price-line subscription-price-line-secondary">
-											<span class="billing-only-monthly"
-												><span class="subscription-price-note">billed monthly</span></span
-											>
-											<span class="billing-only-yearly"
-												><span class="subscription-price-note"
-													>billed as $310 yearly</span
-												></span
-											>
-										</div>
-									</div>
 
-									<div class="subscription-stat-grid">
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Mega Credits</span>
-											<strong>100 / month</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Image Credits</span>
-											<strong>50 / month</strong>
+										<div class="subscription-stat-grid">
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Mega Credits</span>
+												<strong>100 / month</strong>
+											</div>
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Image Credits</span>
+												<strong>50 / month</strong>
+											</div>
 										</div>
 									</div>
 
@@ -2168,33 +2170,35 @@ Your Max plan no longer has a monthly usage limit.</textarea
 									</div>
 								</div>
 								<div class="subscription-card-body">
-									<div class="subscription-price-stack">
-										<div class="subscription-price-line subscription-price-line-primary">
-											<span class="price-amount billing-only-monthly">$100</span>
-											<span class="price-amount billing-only-yearly">$91.67</span>
-											<span class="price-period billing-only-monthly">/month</span>
-											<span class="price-period billing-only-yearly">/month</span>
+									<div class="subscription-plan-summary">
+										<div class="subscription-price-stack">
+											<div class="subscription-price-line subscription-price-line-primary">
+												<span class="price-amount billing-only-monthly">$100</span>
+												<span class="price-amount billing-only-yearly">$91.67</span>
+												<span class="price-period billing-only-monthly">/month</span>
+												<span class="price-period billing-only-yearly">/month</span>
+											</div>
+											<div class="subscription-price-line subscription-price-line-secondary">
+												<span class="billing-only-monthly"
+													><span class="subscription-price-note">billed monthly</span></span
+												>
+												<span class="billing-only-yearly"
+													><span class="subscription-price-note"
+														>billed as $1100 yearly</span
+													></span
+												>
+											</div>
 										</div>
-										<div class="subscription-price-line subscription-price-line-secondary">
-											<span class="billing-only-monthly"
-												><span class="subscription-price-note">billed monthly</span></span
-											>
-											<span class="billing-only-yearly"
-												><span class="subscription-price-note"
-													>billed as $1100 yearly</span
-												></span
-											>
-										</div>
-									</div>
 
-									<div class="subscription-stat-grid">
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Mega Credits</span>
-											<strong>400 / month</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Image Credits</span>
-											<strong>500 / month</strong>
+										<div class="subscription-stat-grid">
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Mega Credits</span>
+												<strong>400 / month</strong>
+											</div>
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Image Credits</span>
+												<strong>500 / month</strong>
+											</div>
 										</div>
 									</div>
 
@@ -2232,6 +2236,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 								id="profile-max-card"
 								class="subscription-card subscription-card-max subscription-plan subscription-plan-max"
 							>
+								<div class="popular-badge popular-badge-limited">LIMITED EDITION</div>
 								<div class="subscription-card-header">
 									<div class="subscription-plan-heading">
 										<div class="tier-badge tier-badge-max">Max</div>
@@ -2242,33 +2247,35 @@ Your Max plan no longer has a monthly usage limit.</textarea
 									</div>
 								</div>
 								<div class="subscription-card-body">
-									<div class="subscription-price-stack">
-										<div class="subscription-price-line subscription-price-line-primary">
-											<span class="price-amount billing-only-monthly">$200</span>
-											<span class="price-amount billing-only-yearly">$183.33</span>
-											<span class="price-period billing-only-monthly">/month</span>
-											<span class="price-period billing-only-yearly">/month</span>
+									<div class="subscription-plan-summary">
+										<div class="subscription-price-stack">
+											<div class="subscription-price-line subscription-price-line-primary">
+												<span class="price-amount billing-only-monthly">$200</span>
+												<span class="price-amount billing-only-yearly">$183.33</span>
+												<span class="price-period billing-only-monthly">/month</span>
+												<span class="price-period billing-only-yearly">/month</span>
+											</div>
+											<div class="subscription-price-line subscription-price-line-secondary">
+												<span class="billing-only-monthly"
+													><span class="subscription-price-note">billed monthly</span></span
+												>
+												<span class="billing-only-yearly"
+													><span class="subscription-price-note"
+														>billed as $2200 yearly</span
+													></span
+												>
+											</div>
 										</div>
-										<div class="subscription-price-line subscription-price-line-secondary">
-											<span class="billing-only-monthly"
-												><span class="subscription-price-note">billed monthly</span></span
-											>
-											<span class="billing-only-yearly"
-												><span class="subscription-price-note"
-													>billed as $2200 yearly</span
-												></span
-											>
-										</div>
-									</div>
 
-									<div class="subscription-stat-grid">
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Mega Credits</span>
-											<strong>Unlimited</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Image Credits</span>
-											<strong>Unlimited</strong>
+										<div class="subscription-stat-grid">
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Mega Credits</span>
+												<strong>Unlimited</strong>
+											</div>
+											<div class="subscription-stat">
+												<span class="subscription-stat-label">Image Credits</span>
+												<strong>Unlimited</strong>
+											</div>
 										</div>
 									</div>
 
@@ -2292,6 +2299,14 @@ Your Max plan no longer has a monthly usage limit.</textarea
 											><span class="feature-text"
 												>Unlimited access to Claude Opus, GPT SOL, and more</span
 											>
+										</li>
+										<li class="feature-item feature-item-warning">
+											<span class="feature-icon">!</span
+											><span class="feature-text">Going away soon</span>
+										</li>
+										<li class="feature-item feature-item-warning">
+											<span class="feature-icon">!</span
+											><span class="feature-text">Buy now to lock this price forever</span>
 										</li>
 									</ul>
 								</div>

--- a/src/index.html
+++ b/src/index.html
@@ -1659,16 +1659,21 @@
 					<h1 id="header-version">What's New in</h1>
 					<ul id="changelog">
 						<li>
-							<b>New image models:</b> Qwen 2.0/Pro, Seedream 4.5/5.0 Pro, Nano Banana variants, and Grok
-							Imagine
+							<b>Limited-edition Max plan:</b> Subscribe during the availability window for unlimited Mega
+							and Image Credits, 1 TB encrypted cloud sync, and continued access at the same price while
+							continuously subscribed
 						</li>
 						<li>
-							<b>Improved LoRA handling:</b> Receive duplicate or unsupported upload feedback, with credit
-							estimates based on model compatibility
+							<b>Clearer plan allowances:</b> Pro includes 100 Mega and 50 Image Credits per month, while
+							Pro Plus includes 400 Mega and 200 Image Credits; yearly plans replenish monthly
 						</li>
 						<li>
-							<b>Image model updates:</b> Imagen 4 Ultra has been retired and Illustrious (Anime) is now
-							the default image model
+							<b>More relevant in-app updates:</b> Important account and product notices can now appear
+							only for the people they apply to
+						</li>
+						<li>
+							<b>More reliable LoRAs and composer:</b> Duplicate LoRAs are handled cleanly, and composer
+							actions remain accessible on narrow screens
 						</li>
 					</ul>
 				</div>

--- a/src/index.html
+++ b/src/index.html
@@ -2089,7 +2089,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										<div class="subscription-price-stack">
 											<div class="subscription-price-line subscription-price-line-primary">
 												<span class="price-amount billing-only-monthly">$30</span>
-												<span class="price-amount billing-only-yearly">$25.83</span>
+												<span class="price-amount billing-only-yearly">$26</span>
 												<span class="price-period billing-only-monthly">/month</span>
 												<span class="price-period billing-only-yearly">/month</span>
 											</div>
@@ -2174,7 +2174,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										<div class="subscription-price-stack">
 											<div class="subscription-price-line subscription-price-line-primary">
 												<span class="price-amount billing-only-monthly">$100</span>
-												<span class="price-amount billing-only-yearly">$91.67</span>
+												<span class="price-amount billing-only-yearly">$92</span>
 												<span class="price-period billing-only-monthly">/month</span>
 												<span class="price-period billing-only-yearly">/month</span>
 											</div>
@@ -2251,7 +2251,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										<div class="subscription-price-stack">
 											<div class="subscription-price-line subscription-price-line-primary">
 												<span class="price-amount billing-only-monthly">$200</span>
-												<span class="price-amount billing-only-yearly">$183.33</span>
+												<span class="price-amount billing-only-yearly">$183</span>
 												<span class="price-period billing-only-monthly">/month</span>
 												<span class="price-period billing-only-yearly">/month</span>
 											</div>

--- a/src/index.html
+++ b/src/index.html
@@ -2197,7 +2197,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 											</div>
 											<div class="subscription-stat">
 												<span class="subscription-stat-label">Image Credits</span>
-												<strong>500 / month</strong>
+												<strong>200 / month</strong>
 											</div>
 										</div>
 									</div>
@@ -2302,11 +2302,21 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										</li>
 										<li class="feature-item feature-item-warning">
 											<span class="feature-icon">!</span
-											><span class="feature-text">Going away soon</span>
+											><span class="feature-text"
+												>Available to new subscribers for a limited time</span
+											>
 										</li>
 										<li class="feature-item feature-item-warning">
 											<span class="feature-icon">!</span
-											><span class="feature-text">Buy now to lock this price forever</span>
+											><span class="feature-text"
+												>Keep Max and this price while continuously subscribed</span
+											>
+										</li>
+										<li class="feature-item feature-item-warning">
+											<span class="feature-icon">!</span
+											><span class="feature-text"
+												>Cancel or switch plans, and Max won't be available again</span
+											>
 										</li>
 									</ul>
 								</div>

--- a/src/services/Announcement.service.ts
+++ b/src/services/Announcement.service.ts
@@ -1,0 +1,104 @@
+import type { Announcement, AnnouncementAction, AnnouncementReceiptEvent } from "../types/Announcement";
+import type { Tables } from "../types/database.types";
+import { supabase } from "./Supabase.service";
+
+type AnnouncementRow = Pick<
+	Tables<"announcements">,
+	"id" | "key" | "title" | "body" | "hero_image_url" | "hero_image_alt" | "action_label" | "action"
+>;
+
+type AnnouncementReceiptRow = Pick<Tables<"announcement_receipts">, "announcement_id" | "dismissed_at">;
+
+function isAction(value: unknown): value is AnnouncementAction {
+	return value === "dismiss" || value === "next";
+}
+
+function normalizeAnnouncement(row: AnnouncementRow): Announcement | null {
+	if (
+		typeof row.id !== "string" ||
+		typeof row.key !== "string" ||
+		typeof row.title !== "string" ||
+		typeof row.body !== "string"
+	) {
+		return null;
+	}
+
+	const action = isAction(row.action) ? row.action : null;
+	const actionLabel =
+		action && typeof row.action_label === "string" && row.action_label.trim() ? row.action_label : null;
+
+	return {
+		id: row.id,
+		key: row.key,
+		title: row.title,
+		body: row.body,
+		heroImageUrl: typeof row.hero_image_url === "string" && row.hero_image_url.trim() ? row.hero_image_url : null,
+		heroImageAlt: typeof row.hero_image_alt === "string" ? row.hero_image_alt : "",
+		actionLabel,
+		action: actionLabel ? action : null
+	};
+}
+
+export async function getEligibleAnnouncements(): Promise<Announcement[]> {
+	const { data, error } = await supabase
+		.from("announcements")
+		.select("id,key,title,body,hero_image_url,hero_image_alt,action_label,action")
+		.order("priority", { ascending: false });
+
+	if (error) {
+		console.warn("Unable to load in-app announcements:", error.message);
+		return [];
+	}
+
+	const announcements = ((data ?? []) as AnnouncementRow[])
+		.map(normalizeAnnouncement)
+		.filter((announcement): announcement is Announcement => announcement !== null);
+	if (!announcements.length) return [];
+
+	const { data: receiptData, error: receiptError } = await supabase
+		.from("announcement_receipts")
+		.select("announcement_id,dismissed_at")
+		.in(
+			"announcement_id",
+			announcements.map((announcement) => announcement.id)
+		);
+
+	if (receiptError) {
+		console.warn("Unable to load announcement receipts:", receiptError.message);
+		return [];
+	}
+
+	const dismissedIds = new Set(
+		((receiptData ?? []) as AnnouncementReceiptRow[])
+			.filter((receipt) => typeof receipt.announcement_id === "string" && receipt.dismissed_at !== null)
+			.map((receipt) => receipt.announcement_id as string)
+	);
+
+	return announcements.filter((announcement) => !dismissedIds.has(announcement.id));
+}
+
+export async function recordAnnouncementReceipt(
+	userId: string,
+	announcementId: string,
+	event: AnnouncementReceiptEvent
+): Promise<void> {
+	const occurredAt = new Date().toISOString();
+	const receipt: Record<string, string> = {
+		user_id: userId,
+		announcement_id: announcementId
+	};
+
+	if (event === "seen") receipt.seen_at = occurredAt;
+	if (event === "dismissed") receipt.dismissed_at = occurredAt;
+	if (event === "actioned") {
+		receipt.actioned_at = occurredAt;
+		receipt.dismissed_at = occurredAt;
+	}
+
+	const { error } = await supabase
+		.from("announcement_receipts")
+		.upsert(receipt, { onConflict: "announcement_id,user_id" });
+	if (error) {
+		console.warn(`Unable to record announcement ${event} receipt:`, error.message);
+	}
+}

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -1633,7 +1633,7 @@ function resolveActiveImageRoute(
 	hasEdgeCredits: boolean
 ): { resolution: ImageRouteResolution; isEditing: boolean } | null {
 	const availability: ImageRouteAvailability = {
-		edgeCredits: hasEdgeCredits,
+		edgeCreditsAvailable: hasEdgeCredits,
 		geminiKey: hasGeminiApiKey(),
 		openRouterKey: hasOpenRouterApiKey()
 	};

--- a/src/services/Supabase.service.ts
+++ b/src/services/Supabase.service.ts
@@ -544,9 +544,11 @@ export async function updateSubscriptionUI(
 		}
 		if (remainingGenerationsEl) {
 			remainingGenerationsEl.textContent =
-				imageGenerationRecord?.remaining_image_generations != null
-					? String(imageGenerationRecord.remaining_image_generations)
-					: "—";
+				tier === "max"
+					? "Unlimited"
+					: imageGenerationRecord?.remaining_image_generations != null
+						? String(imageGenerationRecord.remaining_image_generations)
+						: "—";
 		}
 		if (manageBtn) {
 			if (tier === "free") {
@@ -608,6 +610,11 @@ export async function updateSubscriptionUI(
  */
 export async function isImageGenerationAvailable(): Promise<ImageGenerationPermitted> {
 	try {
+		const subscription = await getUserSubscription();
+		if (getSubscriptionTier(subscription) === "max") {
+			return { enabled: true, type: "all" };
+		}
+
 		const imageGenerationRecord = await getImageGenerationRecord();
 		if (!imageGenerationRecord) return { enabled: true, type: "google_only" }; //free tier, assume available (with API key)
 		if (

--- a/src/services/Supabase.service.ts
+++ b/src/services/Supabase.service.ts
@@ -457,10 +457,6 @@ export function getSubscriptionTier(sub: UserSubscription | null): SubscriptionT
 		return "free";
 	}
 	switch (sub.price_id) {
-		case "price_1S0heGGiJrKwXclR69Ku7XEc": //legacy 29.99 oldstripe
-		case "price_1SDf2NGiJrKwXclRwDs7XOd0": //legacy oldstripe
-		case SubscriptionPriceIDsOld.MAX_MONTHLY:
-		case SubscriptionPriceIDsOld.MAX_YEARLY:
 		case SubscriptionPriceIDs.MAX_MONTHLY:
 		case SubscriptionPriceIDs.MAX_YEARLY:
 			return "max";

--- a/src/services/Sync.service.ts
+++ b/src/services/Sync.service.ts
@@ -2854,9 +2854,11 @@ function attachDexieHooks(): void {
  * Called after auth state change when user is logged in.
  * Checks sync preferences and emits unlock-required event if needed.
  */
-export async function checkSyncOnLogin(): Promise<void> {
+export type SyncLoginCheckResult = "ready" | "interaction-required";
+
+export async function checkSyncOnLogin(): Promise<SyncLoginCheckResult> {
 	const user = await getCurrentUser();
-	if (!user) return;
+	if (!user) return "ready";
 
 	// Check subscription tier
 	const sub = await getUserSubscription();
@@ -2867,8 +2869,9 @@ export async function checkSyncOnLogin(): Promise<void> {
 		const prefs = await fetchSyncPreferences();
 		if (prefs?.syncEnabled) {
 			dispatchAppEvent("sync-unlock-required", { isFirstSetup: false, mode: "final-download" });
+			return "interaction-required";
 		}
-		return;
+		return "ready";
 	}
 
 	const prefs = await fetchSyncPreferences();
@@ -2878,8 +2881,9 @@ export async function checkSyncOnLogin(): Promise<void> {
 		// If they haven't seen the prompt yet, show it.
 		if (!hasSeenSyncPrompt()) {
 			dispatchAppEvent("sync-unlock-required", { isFirstSetup: true, mode: "setup" });
+			return "interaction-required";
 		}
-		return;
+		return "ready";
 	}
 
 	if (!prefs.syncEnabled) {
@@ -2894,14 +2898,18 @@ export async function checkSyncOnLogin(): Promise<void> {
 			} else {
 				dispatchAppEvent("sync-unlock-required", { isFirstSetup: true, mode: "setup" });
 			}
+			return "interaction-required";
 		}
-		return;
+		return "ready";
 	}
 
 	// Sync is enabled — they need to enter their encryption password
 	if (!crypto.isUnlocked()) {
 		dispatchAppEvent("sync-unlock-required", { isFirstSetup: false, mode: "unlock" });
+		return "interaction-required";
 	}
+
+	return "ready";
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2926,6 +2926,38 @@ form {
 	flex-direction: column;
 }
 
+.debug-announcement-form {
+	display: flex;
+	flex-direction: column;
+	gap: 0.65rem;
+	width: min(34rem, 100%);
+	max-height: calc(100dvh - 2rem);
+	padding: 1.5rem;
+	overflow-y: auto;
+	box-sizing: border-box;
+	border: 1px solid var(--card-border);
+	border-radius: 0.75rem;
+	background: var(--modal-bg);
+	box-shadow: var(--modal-shadow);
+}
+
+.debug-announcement-form label {
+	font-size: 0.85rem;
+	font-weight: 700;
+}
+
+.debug-announcement-action-fields {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 0.75rem;
+}
+
+.debug-announcement-action-fields > div {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+
 .message-debug-summary {
 	display: flex;
 	flex-direction: column;
@@ -2973,6 +3005,10 @@ form {
 }
 
 @media (max-width: 640px) {
+	.debug-announcement-action-fields {
+		grid-template-columns: 1fr;
+	}
+
 	.message-debug-row {
 		flex-direction: column;
 		align-items: flex-start;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3465,6 +3465,110 @@ form {
 	overflow-y: auto;
 }
 
+#overlay:has(> .overlay-content > #targeted-announcement:not(.hidden)) > .header {
+	display: none;
+}
+
+.targeted-announcement {
+	position: relative;
+	width: min(34rem, calc(100vw - 2rem));
+	max-height: min(42rem, calc(100dvh - 2rem));
+	overflow-y: auto;
+	border: 1px solid var(--card-border);
+	border-radius: 0.75rem;
+	background: var(--modal-bg);
+	color: var(--modal-fg);
+	box-shadow: var(--modal-shadow);
+}
+
+.targeted-announcement-close {
+	position: absolute;
+	top: 0.75rem;
+	right: 0.75rem;
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.25rem;
+	height: 2.25rem;
+	padding: 0;
+	border: 1px solid var(--input-text-border);
+	border-radius: 0.5rem;
+	background: color-mix(in srgb, var(--modal-bg) 88%, transparent);
+	color: inherit;
+	cursor: pointer;
+}
+
+.targeted-announcement-close:hover {
+	background: color-mix(in srgb, var(--modal-bg) 82%, var(--primary) 18%);
+}
+
+.targeted-announcement-close:focus-visible {
+	outline: 2px solid var(--primary);
+	outline-offset: 2px;
+}
+
+.targeted-announcement-hero {
+	width: 100%;
+	max-height: 16rem;
+	overflow: hidden;
+	border-bottom: 1px solid var(--card-border);
+}
+
+.targeted-announcement-hero img {
+	display: block;
+	width: 100%;
+	height: min(16rem, 38dvh);
+	object-fit: cover;
+}
+
+.targeted-announcement-content {
+	padding: 1.5rem;
+}
+
+.targeted-announcement-content h1 {
+	margin: 0 2.5rem 0.625rem 0;
+	font-size: clamp(1.35rem, 4vw, 1.75rem);
+	line-height: 1.2;
+}
+
+.targeted-announcement-content p {
+	margin: 0;
+	color: var(--text-secondary);
+	line-height: 1.6;
+	white-space: pre-line;
+}
+
+.targeted-announcement-actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 1.5rem;
+}
+
+.targeted-announcement-actions:has(.hidden) {
+	display: none;
+}
+
+.targeted-announcement-actions .btn {
+	min-width: 7rem;
+	padding: 0.65rem 1rem;
+}
+
+@media (max-width: 600px) {
+	.targeted-announcement {
+		width: calc(100vw - 1.5rem);
+		max-height: calc(100dvh - 1.5rem);
+	}
+
+	.targeted-announcement-content {
+		padding: 1.25rem;
+	}
+
+	.targeted-announcement-actions .btn {
+		width: 100%;
+	}
+}
+
 .backButton {
 	position: absolute;
 	top: 1rem;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2031,6 +2031,10 @@ form {
 		box-shadow 0.28s ease;
 }
 
+#form-subscription .subscription-card-free .subscription-price-stack {
+	width: 100%;
+}
+
 #form-subscription .subscription-price-line {
 	display: flex;
 	align-items: baseline;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1909,6 +1909,11 @@ form {
 	z-index: 2;
 }
 
+#form-subscription .popular-badge-limited {
+	background: linear-gradient(135deg, #b91c1c, #ef4444);
+	box-shadow: 0 10px 24px rgba(185, 28, 28, 0.26);
+}
+
 #form-subscription .subscription-card-header {
 	display: flex;
 	flex-direction: column;
@@ -2001,12 +2006,20 @@ form {
 	margin-inline: -1.35rem;
 }
 
+#form-subscription .subscription-plan-summary {
+	display: grid;
+	grid-template-columns: minmax(0, 1.25fr) minmax(8rem, 0.75fr);
+	align-items: stretch;
+	gap: 0.65rem;
+	width: 100%;
+}
+
 #form-subscription .subscription-price-stack {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	gap: 0.5rem;
-	width: 100%;
+	width: auto;
 	min-height: 6.7rem;
 	padding: 1rem;
 	border-radius: 1.2rem;
@@ -2071,17 +2084,17 @@ form {
 
 #form-subscription .subscription-stat-grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	width: 100%;
-	gap: 0.65rem;
+	grid-template-columns: minmax(0, 1fr);
+	min-width: 0;
+	gap: 0.55rem;
 }
 
 #form-subscription .subscription-stat {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	gap: 0.5rem;
-	padding: 0.9rem 0.85rem;
+	gap: 0.35rem;
+	padding: 0.7rem 0.75rem;
 	border-radius: 1rem;
 	background: rgba(255, 255, 255, 0.06);
 	border: 1px solid rgba(148, 163, 184, 0.12);
@@ -2160,6 +2173,18 @@ form {
 
 #form-subscription .feature-item-inherited .feature-icon {
 	display: none;
+}
+
+#form-subscription .feature-item-warning {
+	background: var(--warning-bg, rgba(255, 176, 59, 0.15));
+	border-color: var(--warning-border, rgba(255, 176, 59, 0.3));
+	color: var(--warning-fg, #ffb03b);
+}
+
+#form-subscription .feature-item-warning .feature-icon {
+	background: var(--warning-icon, #ffb03b);
+	box-shadow: none;
+	color: #1f2937;
 }
 
 #form-subscription .feature-item .feature-icon {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1952,7 +1952,7 @@ form {
 }
 
 #form-subscription .tier-badge-max {
-	background: linear-gradient(135deg, #0f172a, #475569);
+	background: linear-gradient(135deg, #e2e8f0, #94a3b8);
 	-webkit-background-clip: text;
 	-webkit-text-fill-color: transparent;
 	background-clip: text;
@@ -2015,9 +2015,7 @@ form {
 }
 
 #form-subscription .subscription-price-stack {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
+	display: grid;
 	gap: 0.5rem;
 	width: auto;
 	min-height: 6.7rem;
@@ -2033,6 +2031,39 @@ form {
 
 #form-subscription .subscription-card-free .subscription-price-stack {
 	width: 100%;
+	align-items: flex-start;
+	justify-items: start;
+	text-align: left;
+}
+
+#form-subscription .subscription-plan:not(.subscription-card-free) .subscription-price-stack {
+	align-items: center;
+	justify-items: center;
+	text-align: center;
+}
+
+#form-subscription .subscription-price-line-primary {
+	grid-row: 2;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.15rem;
+}
+
+#form-subscription .subscription-price-line-secondary {
+	grid-row: 3;
+	align-self: end;
+	justify-content: center;
+	text-align: center;
+}
+
+#form-subscription .subscription-card-free .subscription-price-line-primary {
+	align-items: flex-start;
+}
+
+#form-subscription .subscription-card-free .subscription-price-line-secondary {
+	justify-content: flex-start;
+	text-align: left;
 }
 
 #form-subscription .subscription-price-line {
@@ -2282,12 +2313,12 @@ form {
 }
 
 #form-subscription .subscription-cta-max {
-	background: linear-gradient(135deg, #111827, #334155);
+	background: linear-gradient(135deg, #334155, #475569);
 	box-shadow: 0 14px 32px rgba(15, 23, 42, 0.28);
 }
 
 #form-subscription .subscription-cta-max:hover {
-	background: linear-gradient(135deg, #0f172a, #1e293b);
+	background: linear-gradient(135deg, #1e293b, #334155);
 	box-shadow: 0 18px 36px rgba(15, 23, 42, 0.34);
 }
 

--- a/src/types/Announcement.ts
+++ b/src/types/Announcement.ts
@@ -1,5 +1,7 @@
 import type { Enums } from "./database.types";
 
+export const DEBUG_ANNOUNCEMENT_STORAGE_KEY = "debug-announcement-preview";
+
 export type AnnouncementAction = Enums<"announcement_action">;
 
 export interface Announcement {

--- a/src/types/Announcement.ts
+++ b/src/types/Announcement.ts
@@ -1,0 +1,16 @@
+import type { Enums } from "./database.types";
+
+export type AnnouncementAction = Enums<"announcement_action">;
+
+export interface Announcement {
+	id: string;
+	key: string;
+	title: string;
+	body: string;
+	heroImageUrl: string | null;
+	heroImageAlt: string;
+	actionLabel: string | null;
+	action: AnnouncementAction | null;
+}
+
+export type AnnouncementReceiptEvent = "seen" | "dismissed" | "actioned";

--- a/src/types/Price.ts
+++ b/src/types/Price.ts
@@ -2,10 +2,7 @@
 export enum SubscriptionPriceIDsOld {
 	//PRO
 	PRO_MONTHLY = "price_1SDdbKGiJrKwXclR7hn7fF4s",
-	PRO_YEARLY = "price_1SDeIFGiJrKwXclRCNThnoXH",
-	//MAX
-	MAX_MONTHLY = "price_1SDf2NGiJrKwXclRwDs7XOd0",
-	MAX_YEARLY = "price_1SDf2rGiJrKwXclReGeg8fQo"
+	PRO_YEARLY = "price_1SDeIFGiJrKwXclRCNThnoXH"
 }
 //newstripe
 export enum SubscriptionPriceIDs {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1401,6 +1401,13 @@ export type Database = {
 			};
 		};
 		Functions: {
+			admin_search_users: {
+				Args: { result_limit?: number; search_query: string };
+				Returns: {
+					email: string;
+					user_id: string;
+				}[];
+			};
 			admin_user_emails: {
 				Args: { ids: string[] };
 				Returns: {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -7,7 +7,7 @@
  * Contributors: Treat this as READ-ONLY.
  * If you need schema changes, open an issue describing the required modifications.
  *
- * Generated: 2026-04-30
+ * Generated: 2026-07-19
  */
 
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
@@ -169,6 +169,172 @@ export type Database = {
 					}
 				];
 			};
+			announcement_receipts: {
+				Row: {
+					actioned_at: string | null;
+					announcement_id: string;
+					dismissed_at: string | null;
+					seen_at: string | null;
+					user_id: string;
+				};
+				Insert: {
+					actioned_at?: string | null;
+					announcement_id: string;
+					dismissed_at?: string | null;
+					seen_at?: string | null;
+					user_id?: string;
+				};
+				Update: {
+					actioned_at?: string | null;
+					announcement_id?: string;
+					dismissed_at?: string | null;
+					seen_at?: string | null;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "announcement_receipts_announcement_id_fkey";
+						columns: ["announcement_id"];
+						isOneToOne: false;
+						referencedRelation: "announcements";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "announcement_receipts_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
+						referencedRelation: "admin_dashboard";
+						referencedColumns: ["user_id"];
+					}
+				];
+			};
+			announcement_tier_targets: {
+				Row: {
+					announcement_id: string;
+					tier: string;
+				};
+				Insert: {
+					announcement_id: string;
+					tier: string;
+				};
+				Update: {
+					announcement_id?: string;
+					tier?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "announcement_tier_targets_announcement_id_fkey";
+						columns: ["announcement_id"];
+						isOneToOne: false;
+						referencedRelation: "announcements";
+						referencedColumns: ["id"];
+					}
+				];
+			};
+			announcement_user_targets: {
+				Row: {
+					announcement_id: string;
+					user_id: string;
+				};
+				Insert: {
+					announcement_id: string;
+					user_id: string;
+				};
+				Update: {
+					announcement_id?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "announcement_user_targets_announcement_id_fkey";
+						columns: ["announcement_id"];
+						isOneToOne: false;
+						referencedRelation: "announcements";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "announcement_user_targets_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
+						referencedRelation: "admin_dashboard";
+						referencedColumns: ["user_id"];
+					}
+				];
+			};
+			announcements: {
+				Row: {
+					action: Database["public"]["Enums"]["announcement_action"] | null;
+					action_label: string | null;
+					audience_type: Database["public"]["Enums"]["announcement_audience_type"];
+					body: string;
+					ends_at: string | null;
+					hero_image_alt: string | null;
+					hero_image_url: string | null;
+					id: string;
+					key: string;
+					priority: number;
+					starts_at: string | null;
+					status: Database["public"]["Enums"]["announcement_status"];
+					title: string;
+				};
+				Insert: {
+					action?: Database["public"]["Enums"]["announcement_action"] | null;
+					action_label?: string | null;
+					audience_type: Database["public"]["Enums"]["announcement_audience_type"];
+					body: string;
+					ends_at?: string | null;
+					hero_image_alt?: string | null;
+					hero_image_url?: string | null;
+					id?: string;
+					key: string;
+					priority?: number;
+					starts_at?: string | null;
+					status?: Database["public"]["Enums"]["announcement_status"];
+					title: string;
+				};
+				Update: {
+					action?: Database["public"]["Enums"]["announcement_action"] | null;
+					action_label?: string | null;
+					audience_type?: Database["public"]["Enums"]["announcement_audience_type"];
+					body?: string;
+					ends_at?: string | null;
+					hero_image_alt?: string | null;
+					hero_image_url?: string | null;
+					id?: string;
+					key?: string;
+					priority?: number;
+					starts_at?: string | null;
+					status?: Database["public"]["Enums"]["announcement_status"];
+					title?: string;
+				};
+				Relationships: [];
+			};
+			dashboard_settings: {
+				Row: {
+					settings: Json;
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					settings?: Json;
+					updated_at?: string;
+					user_id: string;
+				};
+				Update: {
+					settings?: Json;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "dashboard_settings_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: true;
+						referencedRelation: "admin_dashboard";
+						referencedColumns: ["user_id"];
+					}
+				];
+			};
 			deleted_comments: {
 				Row: {
 					comment_content: string;
@@ -322,6 +488,68 @@ export type Database = {
 						foreignKeyName: "image_sub_allowance_user_id_fkey";
 						columns: ["user_id"];
 						isOneToOne: true;
+						referencedRelation: "admin_dashboard";
+						referencedColumns: ["user_id"];
+					}
+				];
+			};
+			llm_usage: {
+				Row: {
+					cached_tokens: number;
+					cost: number;
+					created_at: string;
+					end_model: string;
+					fallback: boolean;
+					generation_id: string | null;
+					id: number;
+					input_tokens: number;
+					message_count: number | null;
+					output_tokens: number;
+					reason: string;
+					request_slug: string | null;
+					requested_model: string;
+					tier_snapshot: string | null;
+					user_id: string;
+				};
+				Insert: {
+					cached_tokens?: number;
+					cost: number;
+					created_at?: string;
+					end_model: string;
+					fallback?: boolean;
+					generation_id?: string | null;
+					id?: never;
+					input_tokens: number;
+					message_count?: number | null;
+					output_tokens: number;
+					reason: string;
+					request_slug?: string | null;
+					requested_model: string;
+					tier_snapshot?: string | null;
+					user_id: string;
+				};
+				Update: {
+					cached_tokens?: number;
+					cost?: number;
+					created_at?: string;
+					end_model?: string;
+					fallback?: boolean;
+					generation_id?: string | null;
+					id?: never;
+					input_tokens?: number;
+					message_count?: number | null;
+					output_tokens?: number;
+					reason?: string;
+					request_slug?: string | null;
+					requested_model?: string;
+					tier_snapshot?: string | null;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "llm_usage_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
 						referencedRelation: "admin_dashboard";
 						referencedColumns: ["user_id"];
 					}
@@ -1031,14 +1259,31 @@ export type Database = {
 			admin_dashboard: {
 				Row: {
 					email: string | null;
+					granted_mega_credits: number | null;
+					granted_subscription_image_gens: number | null;
+					image_allowance_period_end: string | null;
+					image_allowance_period_start: string | null;
 					last_activity_timestamp: string | null;
 					last_chat_timestamp: string | null;
+					mega_allowance_period_end: string | null;
+					mega_allowance_period_start: string | null;
 					name: string | null;
+					nano_banana_daily_limit: number | null;
+					nano_banana_remaining_today: number | null;
+					nano_usage_date: string | null;
 					nano_usage_today: number | null;
 					remaining_image_gens: number | null;
 					remaining_mega_credits: number | null;
+					remaining_purchased_image_gens: number | null;
+					remaining_subscription_image_gens: number | null;
+					stripe_customer_id: string | null;
+					stripe_subscription_id: string | null;
+					subscription_cancel_at_period_end: boolean | null;
+					subscription_created_at: string | null;
+					subscription_current_period_end: string | null;
 					subscription_status: string | null;
 					subscription_tier: Database["public"]["Enums"]["subscription_tier"] | null;
+					subscription_updated_at: string | null;
 					sync_storage_quota_bytes: number | null;
 					sync_storage_used_bytes: number | null;
 					total_bucket_storage_bytes: number | null;
@@ -1156,6 +1401,20 @@ export type Database = {
 			};
 		};
 		Functions: {
+			admin_user_emails: {
+				Args: { ids: string[] };
+				Returns: {
+					email: string;
+					user_id: string;
+				}[];
+			};
+			announcement_is_eligible_for_current_user: {
+				Args: {
+					target_announcement_id: string;
+					target_audience_type: Database["public"]["Enums"]["announcement_audience_type"];
+				};
+				Returns: boolean;
+			};
 			can_read_cloud_sync: {
 				Args: { target_user_id: string };
 				Returns: boolean;
@@ -1213,6 +1472,9 @@ export type Database = {
 			wipe_my_synced_data: { Args: never; Returns: undefined };
 		};
 		Enums: {
+			announcement_action: "dismiss" | "next";
+			announcement_audience_type: "all" | "tiers" | "users";
+			announcement_status: "draft" | "published" | "archived";
 			persona_category: "character" | "assistant";
 			spotlight_action: "add" | "remove" | "move";
 			subscription_tier:
@@ -1348,6 +1610,9 @@ export type CompositeTypes<
 export const Constants = {
 	public: {
 		Enums: {
+			announcement_action: ["dismiss", "next"],
+			announcement_audience_type: ["all", "tiers", "users"],
+			announcement_status: ["draft", "published", "archived"],
 			persona_category: ["character", "assistant"],
 			spotlight_action: ["add", "remove", "move"],
 			subscription_tier: [

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1408,13 +1408,6 @@ export type Database = {
 					user_id: string;
 				}[];
 			};
-			announcement_is_eligible_for_current_user: {
-				Args: {
-					target_announcement_id: string;
-					target_audience_type: Database["public"]["Enums"]["announcement_audience_type"];
-				};
-				Returns: boolean;
-			};
 			can_read_cloud_sync: {
 				Args: { target_user_id: string };
 				Returns: boolean;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-	return "1.8.8";
+	return "1.8.9";
 }
 
 export function getSanitized(string: string) {

--- a/src/utils/imageModelRouting.ts
+++ b/src/utils/imageModelRouting.ts
@@ -20,7 +20,7 @@ export type ImageRouteUnavailableReason =
 
 export interface ImageRouteAvailability {
 	/** The account can spend image credits on the edge endpoint (isImageGenerationAvailable -> type "all"). */
-	edgeCredits: boolean;
+	edgeCreditsAvailable: boolean;
 	/** A Gemini API key is configured. */
 	geminiKey: boolean;
 	/** An OpenRouter API key is configured. */
@@ -52,7 +52,7 @@ export function resolveImageModelRoute(
 		if (!model.providers.includes(ImageModelProvider.EDGE)) {
 			return { route: null, reason: "edge-not-supported" };
 		}
-		if (!availability.edgeCredits) {
+		if (!availability.edgeCreditsAvailable) {
 			return { route: null, reason: "edge-no-credits" };
 		}
 		return { route: "edge" };

--- a/src/utils/payloadLimits.ts
+++ b/src/utils/payloadLimits.ts
@@ -24,7 +24,7 @@ export function getPremiumMessageCharacterLimit(
 		return PRO_MESSAGE_CHARACTER_LIMIT;
 	}
 
-	if (tier === "pro_plus") {
+	if (tier === "pro_plus" || tier === "max") {
 		return PRO_PLUS_MESSAGE_CHARACTER_LIMIT;
 	}
 

--- a/src/utils/payloadLimits.ts
+++ b/src/utils/payloadLimits.ts
@@ -24,7 +24,7 @@ export function getPremiumMessageCharacterLimit(
 		return PRO_MESSAGE_CHARACTER_LIMIT;
 	}
 
-	if (tier === "pro_plus" || tier === "max") {
+	if (tier === "pro_plus") {
 		return PRO_PLUS_MESSAGE_CHARACTER_LIMIT;
 	}
 

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -185,3 +185,166 @@ test("eligible announcements render optional hero media and advance through app 
 			])
 		);
 });
+
+test("announcement waits for the cloud sync unlock flow to settle", async ({ page }) => {
+	const userId = "00000000-0000-4000-8000-000000000199";
+	const priceId = "price_1SOU2lKcI9PDo3JBhsT8URS9";
+	const response = (body: unknown, status = 200) => ({
+		status,
+		contentType: "application/json",
+		headers: {
+			"access-control-allow-origin": "*",
+			"access-control-allow-headers": "authorization, apikey, content-type, x-client-info, prefer",
+			"access-control-allow-methods": "GET, POST, PATCH, PUT, DELETE, OPTIONS"
+		},
+		body: JSON.stringify(body)
+	});
+
+	await stubExternalTraffic(page, []);
+	await page.route("https://hglcltvwunzynnzduauy.supabase.co/**/*", async (route) => {
+		const request = route.request();
+		const path = new URL(request.url()).pathname;
+
+		if (request.method() === "OPTIONS") {
+			await route.fulfill(response({}));
+			return;
+		}
+		if (path === "/auth/v1/user") {
+			await route.fulfill(
+				response({
+					id: userId,
+					email: "announcements@example.test",
+					aud: "authenticated",
+					role: "authenticated",
+					app_metadata: {},
+					user_metadata: {},
+					created_at: "2026-01-01T00:00:00.000Z"
+				})
+			);
+			return;
+		}
+		if (path === "/functions/v1/refresh-subscription-allowances") {
+			await route.fulfill(response({ ok: true }));
+			return;
+		}
+		if (path.startsWith("/rest/v1/profiles")) {
+			await route.fulfill(
+				response({ avatar: "", preferredName: "Announcement Tester", systemPromptAddition: "" })
+			);
+			return;
+		}
+		if (path.startsWith("/rest/v1/user_subscriptions")) {
+			await route.fulfill(
+				response({
+					user_id: userId,
+					status: "active",
+					price_id: priceId,
+					current_period_end: "2026-12-31T00:00:00.000Z",
+					cancel_at_period_end: false,
+					stripe_customer_id: "cus_announcement_test"
+				})
+			);
+			return;
+		}
+		if (path.startsWith("/rest/v1/image_generations")) {
+			await route.fulfill(response({ user_id: userId, remaining_image_generations: 10 }));
+			return;
+		}
+		if (path.startsWith("/rest/v1/image_sub_allowance")) {
+			await route.fulfill(response({ remaining_image_generations: 0 }));
+			return;
+		}
+		if (path.startsWith("/rest/v1/user_sync_preferences")) {
+			await route.fulfill(
+				response({
+					sync_enabled: true,
+					encryption_salt: "00",
+					key_verification: "00",
+					key_verification_iv: "00"
+				})
+			);
+			return;
+		}
+		if (path.startsWith("/rest/v1/user_sync_quotas")) {
+			await route.fulfill(response({ storage_used_bytes: 0, storage_quota_bytes: 10 * 1024 * 1024 }));
+			return;
+		}
+		if (path.startsWith("/rest/v1/announcements")) {
+			await route.fulfill(
+				response([
+					{
+						id: "sync-gated-announcement",
+						key: "sync-gated-announcement",
+						title: "Shown after unlock",
+						body: "This should wait for the sync decision.",
+						hero_image_url: null,
+						hero_image_alt: null,
+						action_label: "Got it",
+						action: "dismiss"
+					}
+				])
+			);
+			return;
+		}
+		if (path.startsWith("/rest/v1/announcement_receipts")) {
+			await route.fulfill(response([], request.method() === "POST" ? 201 : 200));
+			return;
+		}
+
+		await route.fulfill(response({}));
+	});
+	await seedLocalSettings(page);
+	await page.addInitScript(
+		({ id, subscriptionPriceId }) => {
+			localStorage.setItem("zodiac-sync-prompt-seen", "true");
+			localStorage.setItem(
+				"sb-hglcltvwunzynnzduauy-auth-token",
+				JSON.stringify({
+					access_token: "playwright-access-token",
+					refresh_token: "playwright-refresh-token",
+					expires_at: Math.floor(Date.now() / 1000) + 3600,
+					expires_in: 3600,
+					token_type: "bearer",
+					user: {
+						id,
+						email: "announcements@example.test",
+						aud: "authenticated",
+						role: "authenticated",
+						app_metadata: {},
+						user_metadata: {},
+						subscriptionPriceId
+					}
+				})
+			);
+		},
+		{ id: userId, subscriptionPriceId: priceId }
+	);
+	await page.goto("/");
+
+	await page.evaluate(
+		({ id, subscriptionPriceId }) => {
+			window.dispatchEvent(
+				new CustomEvent("auth-state-changed", {
+					detail: {
+						loggedIn: true,
+						session: { user: { id } },
+						subscription: {
+							user_id: id,
+							status: "active",
+							price_id: subscriptionPriceId
+						}
+					}
+				})
+			);
+		},
+		{ id: userId, subscriptionPriceId: priceId }
+	);
+
+	await expect(page.locator("#sync-modal")).toBeVisible();
+	await expect(page.getByRole("dialog", { name: "Shown after unlock" })).toBeHidden();
+
+	await page.locator("#btn-sync-skip").click();
+
+	await expect(page.locator("#sync-modal")).toBeHidden();
+	await expect(page.getByRole("dialog", { name: "Shown after unlock" })).toBeVisible();
+});

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -81,7 +81,7 @@ test("eligible announcements render optional hero media and advance through app 
 						id: "announcement-1",
 						key: "max-unlimited-2026",
 						title: "Max is now unlimited",
-						body: "Your Max plan now includes unlimited text and image generation.",
+						body: "Your Max plan no longer has a monthly usage limit.",
 						hero_image_url:
 							"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='360'%3E%3Crect width='800' height='360' fill='%23614a3a'/%3E%3C/svg%3E",
 						hero_image_alt: "A warm abstract illustration",

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+
+import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
+
+test("eligible announcements render optional hero media and advance through app actions", async ({ page }) => {
+	const receiptWrites: Array<Record<string, string>> = [];
+
+	await stubExternalTraffic(page, []);
+	await page.route("https://hglcltvwunzynnzduauy.supabase.co/rest/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		const table = url.pathname.split("/").at(-1);
+
+		if (table === "announcements" && route.request().method() === "GET") {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				headers: { "access-control-allow-origin": "*" },
+				body: JSON.stringify([
+					{
+						id: "announcement-1",
+						key: "max-unlimited-2026",
+						title: "Max is now unlimited",
+						body: "Your Max plan no longer has a monthly usage limit.",
+						hero_image_url:
+							"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='360'%3E%3Crect width='800' height='360' fill='%23614a3a'/%3E%3C/svg%3E",
+						hero_image_alt: "A warm abstract illustration",
+						action_label: "Next",
+						action: "next"
+					},
+					{
+						id: "announcement-2",
+						key: "second-announcement",
+						title: "Ready when you are",
+						body: "There is nothing else you need to configure.",
+						hero_image_url: null,
+						hero_image_alt: null,
+						action_label: "Got it",
+						action: "dismiss"
+					}
+				])
+			});
+			return;
+		}
+
+		if (table === "announcement_receipts" && route.request().method() === "GET") {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				headers: { "access-control-allow-origin": "*" },
+				body: "[]"
+			});
+			return;
+		}
+
+		if (table === "announcement_receipts" && route.request().method() === "POST") {
+			receiptWrites.push(JSON.parse(route.request().postData() ?? "{}") as Record<string, string>);
+			await route.fulfill({
+				status: 201,
+				contentType: "application/json",
+				headers: { "access-control-allow-origin": "*" },
+				body: "[]"
+			});
+			return;
+		}
+
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			headers: { "access-control-allow-origin": "*" },
+			body: "[]"
+		});
+	});
+	await seedLocalSettings(page);
+	await page.goto("/");
+
+	await page.evaluate(() => {
+		window.dispatchEvent(
+			new CustomEvent("auth-state-changed", {
+				detail: {
+					loggedIn: true,
+					session: { user: { id: "user-1" } }
+				}
+			})
+		);
+	});
+
+	const modal = page.getByRole("dialog", { name: "Max is now unlimited" });
+	await expect(modal).toBeVisible();
+	await expect(modal.locator("#targeted-announcement-image")).toBeVisible();
+	await expect(modal.getByRole("button", { name: "Next" })).toBeVisible();
+
+	await modal.getByRole("button", { name: "Next" }).click();
+	await expect(page.getByRole("dialog", { name: "Ready when you are" })).toBeVisible();
+	await expect(page.locator("#targeted-announcement-hero")).toHaveClass(/hidden/);
+
+	await page.getByRole("button", { name: "Got it" }).click();
+	await expect(page.locator("#targeted-announcement")).toBeHidden();
+	await expect
+		.poll(() => receiptWrites)
+		.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					announcement_id: "announcement-1",
+					user_id: "user-1",
+					seen_at: expect.any(String)
+				}),
+				expect.objectContaining({
+					announcement_id: "announcement-1",
+					user_id: "user-1",
+					actioned_at: expect.any(String),
+					dismissed_at: expect.any(String)
+				}),
+				expect.objectContaining({
+					announcement_id: "announcement-2",
+					user_id: "user-1",
+					seen_at: expect.any(String)
+				}),
+				expect.objectContaining({
+					announcement_id: "announcement-2",
+					user_id: "user-1",
+					actioned_at: expect.any(String),
+					dismissed_at: expect.any(String)
+				})
+			])
+		);
+});

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -81,7 +81,7 @@ test("eligible announcements render optional hero media and advance through app 
 						id: "announcement-1",
 						key: "max-unlimited-2026",
 						title: "Max is now unlimited",
-						body: "Your Max plan no longer has a monthly usage limit.",
+						body: "Your Max plan now includes unlimited text and image generation.",
 						hero_image_url:
 							"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='360'%3E%3Crect width='800' height='360' fill='%23614a3a'/%3E%3C/svg%3E",
 						hero_image_alt: "A warm abstract illustration",

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -2,6 +2,67 @@ import { expect, test } from "@playwright/test";
 
 import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
 
+test("debug composer saves a one-time announcement for the next refresh", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await page.route("https://example.test/announcement.svg", async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "image/svg+xml",
+			body: '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="360"><rect width="800" height="360" fill="#614a3a"/></svg>'
+		});
+	});
+	await seedLocalSettings(page);
+	await page.goto("/");
+
+	await page.locator(".navbar-tab").nth(2).click();
+	await page.locator("#btn-debug-announcement").click();
+
+	const form = page.locator("#form-debug-announcement");
+	await expect(form).toBeVisible();
+	await form.locator("#debug-announcement-title").fill("A preview announcement");
+	await form.locator("#debug-announcement-body").fill("This message should appear after refresh.");
+	await form.locator("#debug-announcement-hero-url").fill("https://example.test/announcement.svg");
+	await form.locator("#debug-announcement-hero-alt").fill("A brown preview image");
+	await form.locator("#debug-announcement-action").selectOption("next");
+	await form.locator("#debug-announcement-action-label").fill("Continue");
+	await form.getByRole("button", { name: "Save for next refresh" }).click();
+
+	await expect(form).toBeHidden();
+	await expect
+		.poll(() =>
+			page.evaluate(() => {
+				const stored = localStorage.getItem("debug-announcement-preview");
+				return stored ? JSON.parse(stored) : null;
+			})
+		)
+		.toEqual(
+			expect.objectContaining({
+				title: "A preview announcement",
+				body: "This message should appear after refresh.",
+				heroImageUrl: "https://example.test/announcement.svg",
+				heroImageAlt: "A brown preview image",
+				action: "next",
+				actionLabel: "Continue"
+			})
+		);
+
+	await page.reload();
+
+	const announcement = page.getByRole("dialog", { name: "A preview announcement" });
+	await expect(announcement).toBeVisible();
+	await expect(announcement).toContainText("This message should appear after refresh.");
+	await expect(announcement.locator("#targeted-announcement-image")).toHaveAttribute("alt", "A brown preview image");
+	await expect(announcement.getByRole("button", { name: "Continue" })).toBeVisible();
+	await expect.poll(() => page.evaluate(() => localStorage.getItem("debug-announcement-preview"))).not.toBeNull();
+
+	await page.reload();
+	await expect(page.getByRole("dialog", { name: "A preview announcement" })).toBeVisible();
+
+	await page.getByRole("button", { name: "Continue" }).click();
+	await expect(page.locator("#targeted-announcement")).toBeHidden();
+	await expect.poll(() => page.evaluate(() => localStorage.getItem("debug-announcement-preview"))).toBeNull();
+});
+
 test("eligible announcements render optional hero media and advance through app actions", async ({ page }) => {
 	const receiptWrites: Array<Record<string, string>> = [];
 

--- a/tests/e2e/messages/composer-credit-badge.spec.ts
+++ b/tests/e2e/messages/composer-credit-badge.spec.ts
@@ -177,6 +177,9 @@ async function openMegaComposer(page: Page, width: number): Promise<void> {
 	const badge = page.locator("#image-credits-label");
 	await expect(badge).toHaveText("7 Mega Credits");
 	await dispatchAuthenticatedState(page);
+	await expect(page.locator("#prefer-premium-image-endpoint-toggle .settings-toggle-entry-title")).toHaveText(
+		"Use Image Credits"
+	);
 	await page.evaluate(async () => {
 		const importModule = new Function("path", "return import(path);") as (path: string) => Promise<any>;
 		const { dispatchAppEvent } = await importModule("/events/index.ts");
@@ -185,7 +188,7 @@ async function openMegaComposer(page: Page, width: number): Promise<void> {
 	await expect(badge).toBeVisible();
 }
 
-test("removes Max generation limits from the composer", async ({ page }) => {
+test("hides image generation allowances for Max", async ({ page }) => {
 	await page.setViewportSize({ width: 600, height: 800 });
 	await stubExternalTraffic(page, []);
 	await stubAllowances(page, { priceId: MAX_MONTHLY_PRICE_ID, imageCredits: 0, megaCredits: 0 });
@@ -206,15 +209,13 @@ test("removes Max generation limits from the composer", async ({ page }) => {
 	await expect(page.locator("#subscription-remaining-mega-credits")).toHaveText("Unlimited");
 	await expect(page.locator("#btn-top-up-credits")).toHaveClass(/hidden/);
 	await expect(page.locator("#prefer-premium-image-endpoint-toggle")).not.toHaveClass(/hidden/);
+	await expect(page.locator("#prefer-premium-image-endpoint-toggle .settings-toggle-entry-title")).toHaveText(
+		"Use Hosted Image Generation"
+	);
 
 	await page.locator("#btn-image").click();
 	await expect(page.locator("#btn-image")).toHaveClass(/btn-toggled/);
 	await expect(page.locator("#image-credits-label")).toBeHidden();
-	await expect(page.locator("#btn-send")).toBeEnabled();
-
-	await page.locator("#btn-image").click();
-	await page.locator("#messageInput").fill("x".repeat(15_001));
-	await expect(page.locator("#message-limit-indicator")).toBeHidden();
 	await expect(page.locator("#btn-send")).toBeEnabled();
 });
 

--- a/tests/e2e/messages/composer-credit-badge.spec.ts
+++ b/tests/e2e/messages/composer-credit-badge.spec.ts
@@ -5,6 +5,7 @@ import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
 const SUPABASE_HOST = "hglcltvwunzynnzduauy.supabase.co";
 const TEST_USER_ID = "00000000-0000-4000-8000-0000000005728";
 const PRO_MONTHLY_PRICE_ID = "price_1SOU2lKcI9PDo3JBhsT8URS9";
+const MAX_MONTHLY_PRICE_ID = "price_1T9DCYKcI9PDo3JBsFc4nlZa";
 
 function jsonResponse(body: unknown) {
 	return {
@@ -19,7 +20,11 @@ function jsonResponse(body: unknown) {
 	};
 }
 
-async function stubMegaAllowance(page: Page): Promise<void> {
+async function stubAllowances(
+	page: Page,
+	options: { priceId?: string; imageCredits?: number; megaCredits?: number } = {}
+): Promise<void> {
+	const { priceId = PRO_MONTHLY_PRICE_ID, imageCredits = 7, megaCredits = 7 } = options;
 	await page.route(`https://${SUPABASE_HOST}/**/*`, async (route: Route) => {
 		const request = route.request();
 		const url = new URL(request.url());
@@ -54,7 +59,7 @@ async function stubMegaAllowance(page: Page): Promise<void> {
 				jsonResponse({
 					user_id: TEST_USER_ID,
 					status: "active",
-					price_id: PRO_MONTHLY_PRICE_ID,
+					price_id: priceId,
 					current_period_end: "2026-12-31T00:00:00.000Z",
 					cancel_at_period_end: false,
 					stripe_customer_id: "cus_mega_layout_playwright"
@@ -64,12 +69,12 @@ async function stubMegaAllowance(page: Page): Promise<void> {
 		}
 
 		if (url.pathname.startsWith("/rest/v1/mega_credits")) {
-			await route.fulfill(jsonResponse({ user_id: TEST_USER_ID, remaining_mega_credits: 7 }));
+			await route.fulfill(jsonResponse({ user_id: TEST_USER_ID, remaining_mega_credits: megaCredits }));
 			return;
 		}
 
 		if (url.pathname.startsWith("/rest/v1/image_generations")) {
-			await route.fulfill(jsonResponse({ user_id: TEST_USER_ID, remaining_image_generations: 7 }));
+			await route.fulfill(jsonResponse({ user_id: TEST_USER_ID, remaining_image_generations: imageCredits }));
 			return;
 		}
 
@@ -120,9 +125,13 @@ async function seedSupabaseSession(page: Page): Promise<void> {
 	);
 }
 
-async function dispatchAuthenticatedState(page: Page): Promise<void> {
+async function dispatchAuthenticatedState(
+	page: Page,
+	options: { priceId?: string; imageCredits?: number } = {}
+): Promise<void> {
+	const { priceId = PRO_MONTHLY_PRICE_ID, imageCredits = 7 } = options;
 	await page.evaluate(
-		async ({ userId, priceId }) => {
+		async ({ userId, priceId, imageCredits }) => {
 			const importModule = new Function("path", "return import(path);") as (path: string) => Promise<any>;
 			const { dispatchAppEvent } = await importModule("/events/index.ts");
 			dispatchAppEvent("auth-state-changed", {
@@ -135,17 +144,17 @@ async function dispatchAuthenticatedState(page: Page): Promise<void> {
 					cancel_at_period_end: false,
 					stripe_customer_id: "cus_mega_layout_playwright"
 				},
-				imageGenerationRecord: { user_id: userId, remaining_image_generations: 7 }
+				imageGenerationRecord: { user_id: userId, remaining_image_generations: imageCredits }
 			});
 		},
-		{ userId: TEST_USER_ID, priceId: PRO_MONTHLY_PRICE_ID }
+		{ userId: TEST_USER_ID, priceId, imageCredits }
 	);
 }
 
 async function openMegaComposer(page: Page, width: number): Promise<void> {
 	await page.setViewportSize({ width, height: 800 });
 	await stubExternalTraffic(page, []);
-	await stubMegaAllowance(page);
+	await stubAllowances(page);
 	await seedLocalSettings(page);
 	await seedSupabaseSession(page);
 	await page.goto("/");
@@ -175,6 +184,39 @@ async function openMegaComposer(page: Page, width: number): Promise<void> {
 	});
 	await expect(badge).toBeVisible();
 }
+
+test("removes Max generation limits from the composer", async ({ page }) => {
+	await page.setViewportSize({ width: 600, height: 800 });
+	await stubExternalTraffic(page, []);
+	await stubAllowances(page, { priceId: MAX_MONTHLY_PRICE_ID, imageCredits: 0, megaCredits: 0 });
+	await seedLocalSettings(page);
+	await seedSupabaseSession(page);
+	await page.goto("/");
+
+	await expect
+		.poll(() =>
+			page.evaluate(
+				() => (window as typeof window & { __zodiacAuthStateChanges?: number }).__zodiacAuthStateChanges ?? 0
+			)
+		)
+		.toBeGreaterThan(0);
+	await dispatchAuthenticatedState(page, { priceId: MAX_MONTHLY_PRICE_ID, imageCredits: 0 });
+
+	await expect(page.locator("#subscription-remaining-generations")).toHaveText("Unlimited");
+	await expect(page.locator("#subscription-remaining-mega-credits")).toHaveText("Unlimited");
+	await expect(page.locator("#btn-top-up-credits")).toHaveClass(/hidden/);
+	await expect(page.locator("#prefer-premium-image-endpoint-toggle")).not.toHaveClass(/hidden/);
+
+	await page.locator("#btn-image").click();
+	await expect(page.locator("#btn-image")).toHaveClass(/btn-toggled/);
+	await expect(page.locator("#image-credits-label")).toBeHidden();
+	await expect(page.locator("#btn-send")).toBeEnabled();
+
+	await page.locator("#btn-image").click();
+	await page.locator("#messageInput").fill("x".repeat(15_001));
+	await expect(page.locator("#message-limit-indicator")).toBeHidden();
+	await expect(page.locator("#btn-send")).toBeEnabled();
+});
 
 function getComposerLayout() {
 	const messageBox = document.querySelector<HTMLElement>("#message-box");

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -96,13 +96,11 @@ test("presents Max text and image generation as unlimited", async ({ page }) => 
 	await openSubscriptionOverlay(page);
 
 	const stats = page.locator("#profile-max-card .subscription-stat");
-	await expect(stats.nth(0).locator(".subscription-stat-label")).toHaveText("Text Generation");
+	await expect(stats.nth(0).locator(".subscription-stat-label")).toHaveText("Mega Credits");
 	await expect(stats.nth(0).locator("strong")).toHaveText("Unlimited");
-	await expect(stats.nth(1).locator(".subscription-stat-label")).toHaveText("Image Generation");
+	await expect(stats.nth(1).locator(".subscription-stat-label")).toHaveText("Image Credits");
 	await expect(stats.nth(1).locator("strong")).toHaveText("Unlimited");
-	await expect(page.locator("#profile-max-card")).toContainText(
-		"Unlimited access to all hosted text and image models"
-	);
+	await expect(page.locator("#profile-max-card")).toContainText("Unlimited access to Claude Opus, GPT-5.5, and more");
 });
 
 test("plans use their own close button instead of the overlay back bar", async ({ page }) => {

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -89,6 +89,22 @@ test("renders FAQ questions in one column at desktop widths", async ({ page }) =
 	expect(faqColumns, "FAQ questions should not be displayed side by side").toBe(1);
 });
 
+test("presents Max text and image generation as unlimited", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openSubscriptionOverlay(page);
+
+	const stats = page.locator("#profile-max-card .subscription-stat");
+	await expect(stats.nth(0).locator(".subscription-stat-label")).toHaveText("Text Generation");
+	await expect(stats.nth(0).locator("strong")).toHaveText("Unlimited");
+	await expect(stats.nth(1).locator(".subscription-stat-label")).toHaveText("Image Generation");
+	await expect(stats.nth(1).locator("strong")).toHaveText("Unlimited");
+	await expect(page.locator("#profile-max-card")).toContainText(
+		"Unlimited access to all hosted text and image models"
+	);
+});
+
 test("plans use their own close button instead of the overlay back bar", async ({ page }) => {
 	await stubExternalTraffic(page, []);
 	await seedLocalSettings(page);

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -100,7 +100,7 @@ test("presents Max text and image generation as unlimited", async ({ page }) => 
 	await expect(stats.nth(0).locator("strong")).toHaveText("Unlimited");
 	await expect(stats.nth(1).locator(".subscription-stat-label")).toHaveText("Image Credits");
 	await expect(stats.nth(1).locator("strong")).toHaveText("Unlimited");
-	await expect(page.locator("#profile-max-card")).toContainText("Unlimited access to Claude Opus, GPT-5.5, and more");
+	await expect(page.locator("#profile-max-card")).toContainText("Unlimited access to Claude Opus, GPT SOL, and more");
 });
 
 test("plans use their own close button instead of the overlay back bar", async ({ page }) => {

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -26,6 +26,15 @@ test("keeps subscription plan cards within the pricing panel on mobile", async (
 	await firstCard.locator(".subscription-card-header").click();
 	await expect(firstCard).toHaveClass(/subscription-card-expanded/);
 	expect(await firstCard.evaluate((card) => getComputedStyle(card).padding)).toBe(collapsedPadding);
+	const freePriceFillsCard = await firstCard.locator(".subscription-price-stack").evaluate((price) => {
+		const card = price.closest<HTMLElement>(".subscription-card");
+		if (!card) throw new Error("Missing Free card");
+		const cardStyle = getComputedStyle(card);
+		const availableWidth =
+			card.clientWidth - Number.parseFloat(cardStyle.paddingLeft) - Number.parseFloat(cardStyle.paddingRight);
+		return price.getBoundingClientRect().width >= availableWidth - 1;
+	});
+	expect(freePriceFillsCard, "Free card price panel should fill the available width").toBe(true);
 
 	await firstCard.hover();
 	expect(await firstCard.evaluate((card) => getComputedStyle(card).transform)).toBe("none");
@@ -130,6 +139,17 @@ test("presents Max text and image generation as unlimited", async ({ page }) => 
 	await expect(stats.nth(1).locator(".subscription-stat-label")).toHaveText("Image Credits");
 	await expect(stats.nth(1).locator("strong")).toHaveText("Unlimited");
 	await expect(page.locator("#profile-max-card")).toContainText("Unlimited access to Claude Opus, GPT SOL, and more");
+});
+
+test("rounds yearly-equivalent subscription prices", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openSubscriptionOverlay(page);
+
+	await expect(page.locator("#profile-pro-card .price-amount.billing-only-yearly")).toHaveText("$26");
+	await expect(page.locator("#profile-pro-plus-card .price-amount.billing-only-yearly")).toHaveText("$92");
+	await expect(page.locator("#profile-max-card .price-amount.billing-only-yearly")).toHaveText("$183");
 });
 
 test("plans use their own close button instead of the overlay back bar", async ({ page }) => {

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -51,12 +51,20 @@ test("keeps subscription plan cards within the pricing panel on mobile", async (
 	expect(layout.hasHorizontalOverflow, "Subscription pricing should not overflow horizontally").toBe(false);
 });
 
-test("keeps the best-value badge compact and credit cards side by side on mobile", async ({ page }) => {
+test("marks Max as limited edition and keeps paid-plan summaries compact on mobile", async ({ page }) => {
 	await page.setViewportSize({ width: 496, height: 961 });
 	await stubExternalTraffic(page, []);
 	await seedLocalSettings(page);
 	await page.goto("/");
 	await openSubscriptionOverlay(page);
+
+	const maxCard = page.locator("#profile-max-card");
+	const limitedBadge = maxCard.locator(".popular-badge-limited");
+	await expect(limitedBadge).toHaveText("LIMITED EDITION");
+	await expect(limitedBadge).toHaveClass(/popular-badge/);
+	await expect(maxCard).toContainText("Going away soon");
+	await expect(maxCard).toContainText("Buy now to lock this price forever");
+	expect(await limitedBadge.evaluate((element) => getComputedStyle(element).backgroundImage)).toMatch(/185/);
 
 	const proPlusCard = page.locator("#profile-pro-plus-card");
 	const badge = proPlusCard.locator(".popular-badge");
@@ -70,10 +78,31 @@ test("keeps the best-value badge compact and credit cards side by side on mobile
 	expect(await badge.evaluate((element) => getComputedStyle(element).fontSize)).toBe(collapsedBadgeStyle.fontSize);
 	expect(await badge.evaluate((element) => getComputedStyle(element).padding)).toBe(collapsedBadgeStyle.padding);
 
-	const statColumns = await proPlusCard
-		.locator(".subscription-stat-grid")
-		.evaluate((element) => getComputedStyle(element).gridTemplateColumns.split(" ").length);
-	expect(statColumns, "Credit cards should remain side by side on mobile").toBe(2);
+	for (const cardId of ["profile-pro-card", "profile-pro-plus-card", "profile-max-card"]) {
+		const card = page.locator(`#${cardId}`);
+		if (cardId !== "profile-pro-plus-card") {
+			await card.locator(".subscription-card-header").click();
+		}
+		await expect(card).toHaveClass(/subscription-card-expanded/);
+
+		const summaryLayout = await card.locator(".subscription-plan-summary").evaluate((summary) => {
+			const price = summary.querySelector<HTMLElement>(".subscription-price-stack");
+			const stats = summary.querySelector<HTMLElement>(".subscription-stat-grid");
+			if (!price || !stats) throw new Error("Missing paid-plan summary elements");
+
+			const priceBounds = price.getBoundingClientRect();
+			const statsBounds = stats.getBoundingClientRect();
+			return {
+				priceBeforeStats: priceBounds.right <= statsBounds.left,
+				statColumns: getComputedStyle(stats).gridTemplateColumns.split(" ").length,
+				statRows: getComputedStyle(stats).gridTemplateRows.split(" ").length
+			};
+		});
+
+		expect(summaryLayout.priceBeforeStats, `${cardId} should place credits beside the price`).toBe(true);
+		expect(summaryLayout.statColumns, `${cardId} credits should use one column`).toBe(1);
+		expect(summaryLayout.statRows, `${cardId} credits should stack vertically`).toBe(2);
+	}
 });
 
 test("renders FAQ questions in one column at desktop widths", async ({ page }) => {

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -71,9 +71,9 @@ test("marks Max as limited edition and keeps paid-plan summaries compact on mobi
 	const limitedBadge = maxCard.locator(".popular-badge-limited");
 	await expect(limitedBadge).toHaveText("LIMITED EDITION");
 	await expect(limitedBadge).toHaveClass(/popular-badge/);
-	await expect(maxCard).toContainText("Going away soon");
-	await expect(maxCard).toContainText("Buy now to lock this price forever");
-	expect(await limitedBadge.evaluate((element) => getComputedStyle(element).backgroundImage)).toMatch(/185/);
+	await expect(maxCard).toContainText("Available to new subscribers for a limited time");
+	await expect(maxCard).toContainText("Keep Max and this price while continuously subscribed");
+	await expect(maxCard).toContainText("Cancel or switch plans, and Max won't be available again");
 
 	const proPlusCard = page.locator("#profile-pro-plus-card");
 	const badge = proPlusCard.locator(".popular-badge");
@@ -150,6 +150,76 @@ test("rounds yearly-equivalent subscription prices", async ({ page }) => {
 	await expect(page.locator("#profile-pro-card .price-amount.billing-only-yearly")).toHaveText("$26");
 	await expect(page.locator("#profile-pro-plus-card .price-amount.billing-only-yearly")).toHaveText("$92");
 	await expect(page.locator("#profile-max-card .price-amount.billing-only-yearly")).toHaveText("$183");
+});
+
+test("stacks and centers subscription price periods", async ({ page }) => {
+	await page.setViewportSize({ width: 1600, height: 1000 });
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openSubscriptionOverlay(page);
+
+	const priceLayouts = await page.evaluate(() => {
+		const visible = (element: Element): boolean => {
+			const style = getComputedStyle(element);
+			return style.display !== "none" && style.visibility !== "hidden";
+		};
+
+		return ["profile-free-card", "profile-pro-card", "profile-pro-plus-card", "profile-max-card"].map((cardId) => {
+			const card = document.getElementById(cardId);
+			const stack = card?.querySelector<HTMLElement>(".subscription-price-stack");
+			const primary = card?.querySelector<HTMLElement>(".subscription-price-line-primary");
+			const amount = primary
+				? Array.from(primary.querySelectorAll<HTMLElement>(".price-amount")).find(visible)
+				: undefined;
+			const period = primary
+				? Array.from(primary.querySelectorAll<HTMLElement>(".price-period")).find(visible)
+				: undefined;
+
+			if (!card || !stack || !primary || !amount || !period) {
+				throw new Error(`Missing price layout elements for ${cardId}`);
+			}
+
+			const stackBounds = stack.getBoundingClientRect();
+			const amountBounds = amount.getBoundingClientRect();
+			const periodBounds = period.getBoundingClientRect();
+			const groupLeft = Math.min(amountBounds.left, periodBounds.left);
+			const groupRight = Math.max(amountBounds.right, periodBounds.right);
+			const stackStyle = getComputedStyle(stack);
+			const primaryStyle = getComputedStyle(primary);
+
+			return {
+				cardId,
+				periodBelowAmount: periodBounds.top >= amountBounds.bottom - 1,
+				groupCenteredHorizontally:
+					Math.abs(groupLeft + (groupRight - groupLeft) / 2 - (stackBounds.left + stackBounds.width / 2)) <=
+					1,
+				stackAlignItems: stackStyle.alignItems,
+				stackJustifyItems: stackStyle.justifyItems,
+				stackTextAlign: stackStyle.textAlign,
+				primaryFlexDirection: primaryStyle.flexDirection
+			};
+		});
+	});
+
+	for (const layout of priceLayouts) {
+		expect(layout.periodBelowAmount, `${layout.cardId} should put /month below the price`).toBe(true);
+		expect(layout.primaryFlexDirection, `${layout.cardId} price period should be on its own line`).toBe("column");
+
+		if (layout.cardId === "profile-free-card") {
+			expect(layout.stackAlignItems).toBe("flex-start");
+			expect(layout.stackJustifyItems).toBe("start");
+			expect(layout.groupCenteredHorizontally).toBe(false);
+		} else {
+			expect(
+				layout.groupCenteredHorizontally,
+				`${layout.cardId} price group should be horizontally centered`
+			).toBe(true);
+			expect(layout.stackAlignItems).toBe("center");
+			expect(layout.stackJustifyItems).toBe("center");
+			expect(layout.stackTextAlign).toBe("center");
+		}
+	}
 });
 
 test("plans use their own close button instead of the overlay back bar", async ({ page }) => {

--- a/tests/integration/settings/premium-endpoint-sync.test.ts
+++ b/tests/integration/settings/premium-endpoint-sync.test.ts
@@ -30,7 +30,10 @@ function bootstrapSettingsDom(): void {
 		<div id="openrouter-api-key-error" class="hidden"></div>
 		<div id="prefer-premium-endpoint-toggle"></div>
 		<input id="preferPremiumEndpoint" type="checkbox">
-		<div id="prefer-premium-image-endpoint-toggle"></div>
+		<div id="prefer-premium-image-endpoint-toggle">
+			<span class="settings-toggle-entry-title"></span>
+			<span class="settings-toggle-entry-subtitle"></span>
+		</div>
 		<input id="preferPremiumImageEndpoint" type="checkbox">
 
 		<input id="maxTokens" value="1000">

--- a/tests/unit/imageModelRouting.test.ts
+++ b/tests/unit/imageModelRouting.test.ts
@@ -15,14 +15,14 @@ function makeModel(providers: ImageModelProvider[]): ImageModelDefinition {
 	};
 }
 
-const NOTHING: ImageRouteAvailability = { edgeCredits: false, geminiKey: false, openRouterKey: false };
+const NOTHING: ImageRouteAvailability = { edgeCreditsAvailable: false, geminiKey: false, openRouterKey: false };
 
 describe("resolveImageModelRoute", () => {
 	describe("prefer edge (image premium endpoint ON) — strict edge-only", () => {
 		it("routes to edge when the model supports edge and credits are available", () => {
 			const result = resolveImageModelRoute(makeModel([ImageModelProvider.EDGE]), true, {
 				...NOTHING,
-				edgeCredits: true
+				edgeCreditsAvailable: true
 			});
 			expect(result).toEqual({ route: "edge" });
 		});
@@ -32,7 +32,7 @@ describe("resolveImageModelRoute", () => {
 				makeModel([ImageModelProvider.GOOGLE, ImageModelProvider.EDGE]),
 				true,
 				{
-					edgeCredits: true,
+					edgeCreditsAvailable: true,
 					geminiKey: true,
 					openRouterKey: false
 				}
@@ -50,7 +50,7 @@ describe("resolveImageModelRoute", () => {
 				makeModel([ImageModelProvider.GOOGLE, ImageModelProvider.EDGE]),
 				true,
 				{
-					edgeCredits: false,
+					edgeCreditsAvailable: false,
 					geminiKey: true,
 					openRouterKey: false
 				}
@@ -62,7 +62,7 @@ describe("resolveImageModelRoute", () => {
 			const result = resolveImageModelRoute(makeModel([ImageModelProvider.GOOGLE]), true, {
 				...NOTHING,
 				geminiKey: true,
-				edgeCredits: true
+				edgeCreditsAvailable: true
 			});
 			expect(result).toEqual({ route: null, reason: "edge-not-supported" });
 		});
@@ -99,7 +99,7 @@ describe("resolveImageModelRoute", () => {
 			const result = resolveImageModelRoute(
 				makeModel([ImageModelProvider.OPENROUTER, ImageModelProvider.GOOGLE]),
 				false,
-				{ edgeCredits: false, geminiKey: true, openRouterKey: true }
+				{ edgeCreditsAvailable: false, geminiKey: true, openRouterKey: true }
 			);
 			expect(result).toEqual({ route: "openrouter" });
 		});
@@ -109,7 +109,7 @@ describe("resolveImageModelRoute", () => {
 				makeModel([ImageModelProvider.GOOGLE, ImageModelProvider.EDGE]),
 				false,
 				{
-					edgeCredits: true,
+					edgeCreditsAvailable: true,
 					geminiKey: false,
 					openRouterKey: false
 				}
@@ -124,7 +124,7 @@ describe("resolveImageModelRoute", () => {
 
 		it("fails with byok-not-supported when the model is edge-only", () => {
 			const result = resolveImageModelRoute(makeModel([ImageModelProvider.EDGE]), false, {
-				edgeCredits: true,
+				edgeCreditsAvailable: true,
 				geminiKey: true,
 				openRouterKey: true
 			});

--- a/tests/unit/payload-limits.test.ts
+++ b/tests/unit/payload-limits.test.ts
@@ -18,10 +18,10 @@ describe("payload limits", () => {
 		expect(getPremiumMessageCharacterLimit("max", false)).toBeNull();
 	});
 
-	it("returns premium endpoint character limits for credit-limited paid tiers", () => {
+	it("returns premium endpoint character limits by paid tier", () => {
 		expect(getPremiumMessageCharacterLimit("pro", true)).toBe(PRO_MESSAGE_CHARACTER_LIMIT);
 		expect(getPremiumMessageCharacterLimit("pro_plus", true)).toBe(PRO_PLUS_MESSAGE_CHARACTER_LIMIT);
-		expect(getPremiumMessageCharacterLimit("max", true)).toBeNull();
+		expect(getPremiumMessageCharacterLimit("max", true)).toBe(PRO_PLUS_MESSAGE_CHARACTER_LIMIT);
 	});
 
 	it("counts unicode code points instead of UTF-16 code units", () => {

--- a/tests/unit/payload-limits.test.ts
+++ b/tests/unit/payload-limits.test.ts
@@ -18,10 +18,10 @@ describe("payload limits", () => {
 		expect(getPremiumMessageCharacterLimit("max", false)).toBeNull();
 	});
 
-	it("returns premium endpoint character limits by paid tier", () => {
+	it("returns premium endpoint character limits for credit-limited paid tiers", () => {
 		expect(getPremiumMessageCharacterLimit("pro", true)).toBe(PRO_MESSAGE_CHARACTER_LIMIT);
 		expect(getPremiumMessageCharacterLimit("pro_plus", true)).toBe(PRO_PLUS_MESSAGE_CHARACTER_LIMIT);
-		expect(getPremiumMessageCharacterLimit("max", true)).toBe(PRO_PLUS_MESSAGE_CHARACTER_LIMIT);
+		expect(getPremiumMessageCharacterLimit("max", true)).toBeNull();
 	});
 
 	it("counts unicode code points instead of UTF-16 code units", () => {


### PR DESCRIPTION
## Summary
- promote the verified v1.8.9 release from main to production
- publish the limited-edition Max offer, aligned plan allowances, targeted announcements, and LoRA/composer fixes
- deploy only after the corresponding zozo-edge entitlement release is live and verified

## Validation
- release PR #222 passed the full Merge Gate and Cloudflare preview
- npm run build
- npm run lint
- npm test (125 passed)
- subscription Playwright spec (7 passed)

This production promotion does not require a release-classification label.