### PR TITLE
Correct Pro Plus credits and prepare Stripe account migration

### DIFF
--- a/src/components/static/CloudSync.component.ts
+++ b/src/components/static/CloudSync.component.ts
@@ -615,6 +615,10 @@ onAppEvent(
 
 			const startupUserId = session?.user.id;
 			if (!startupUserId) return;
+			// Supabase can emit the same authenticated session again while its first
+			// startup check is still loading. Keep one unlock flow active per user so
+			// a slower duplicate cannot reopen the modal after the user dismisses it.
+			if (syncStartupUserId === startupUserId) return;
 			syncStartupUserId = startupUserId;
 
 			const tier = getSubscriptionTier(subscription ?? null);

--- a/src/components/static/Onboarding.component.ts
+++ b/src/components/static/Onboarding.component.ts
@@ -3,7 +3,7 @@
  */
 
 import { OnboardingPath, OnboardingStep } from "../../types/Onboarding";
-import { SubscriptionPriceIDs } from "../../types/Price";
+import type { SubscriptionPurchaseType } from "../../types/Price";
 import type { ColorTheme, ThemeMode } from "../../types/Theme";
 import * as onboardingService from "../../services/Onboarding.service";
 import * as supabaseService from "../../services/Supabase.service";
@@ -839,32 +839,35 @@ function setOnboardingBillingMode(mode: OnboardingBillingMode): void {
 	}
 }
 
-function getSelectedPriceIdForPlan(plan: OnboardingPlanType, billingMode: OnboardingBillingMode): string {
+function getSelectedPurchaseTypeForPlan(
+	plan: OnboardingPlanType,
+	billingMode: OnboardingBillingMode
+): SubscriptionPurchaseType {
 	switch (plan) {
 		case "pro":
-			return billingMode === "yearly" ? SubscriptionPriceIDs.PRO_YEARLY : SubscriptionPriceIDs.PRO_MONTHLY;
+			return billingMode === "yearly" ? "pro_yearly" : "pro_monthly";
 		case "pro_plus":
-			return billingMode === "yearly"
-				? SubscriptionPriceIDs.PRO_PLUS_YEARLY
-				: SubscriptionPriceIDs.PRO_PLUS_MONTHLY;
+			return billingMode === "yearly" ? "pro_plus_yearly" : "pro_plus_monthly";
 		case "max":
-			return billingMode === "yearly" ? SubscriptionPriceIDs.MAX_YEARLY : SubscriptionPriceIDs.MAX_MONTHLY;
+			return billingMode === "yearly" ? "max_yearly" : "max_monthly";
 	}
 }
 
-function getSubscriptionSummaryFromPriceId(priceId: string | null): OnboardingSubscriptionSummary | null {
-	switch (priceId) {
-		case SubscriptionPriceIDs.PRO_MONTHLY:
+function getSubscriptionSummaryFromPurchaseType(
+	purchaseType: SubscriptionPurchaseType | null
+): OnboardingSubscriptionSummary | null {
+	switch (purchaseType) {
+		case "pro_monthly":
 			return { planLabel: "Pro", billingLabel: "Monthly" };
-		case SubscriptionPriceIDs.PRO_YEARLY:
+		case "pro_yearly":
 			return { planLabel: "Pro", billingLabel: "Yearly" };
-		case SubscriptionPriceIDs.PRO_PLUS_MONTHLY:
+		case "pro_plus_monthly":
 			return { planLabel: "Pro Plus", billingLabel: "Monthly" };
-		case SubscriptionPriceIDs.PRO_PLUS_YEARLY:
+		case "pro_plus_yearly":
 			return { planLabel: "Pro Plus", billingLabel: "Yearly" };
-		case SubscriptionPriceIDs.MAX_MONTHLY:
+		case "max_monthly":
 			return { planLabel: "Max", billingLabel: "Monthly" };
-		case SubscriptionPriceIDs.MAX_YEARLY:
+		case "max_yearly":
 			return { planLabel: "Max", billingLabel: "Yearly" };
 		default:
 			return null;
@@ -924,7 +927,9 @@ function initializeOnboardingPricing(): void {
 				event.preventDefault();
 				event.stopImmediatePropagation();
 				void (async () => {
-					onboardingService.setSelectedPriceId(getSelectedPriceIdForPlan(plan, getOnboardingBillingMode()));
+					onboardingService.setSelectedPurchaseType(
+						getSelectedPurchaseTypeForPlan(plan, getOnboardingBillingMode())
+					);
 					await routeToCloudSyncOrSettings();
 				})();
 			},
@@ -1138,21 +1143,6 @@ function setupRegistration(): void {
 }
 
 /**
- * Map price IDs to Stripe purchase type strings
- */
-function getPurchaseTypeFromPriceId(priceId: string): string | null {
-	const mapping: Record<string, string> = {
-		[SubscriptionPriceIDs.PRO_MONTHLY]: "pro_monthly",
-		[SubscriptionPriceIDs.PRO_YEARLY]: "pro_yearly",
-		[SubscriptionPriceIDs.PRO_PLUS_MONTHLY]: "pro_plus_monthly",
-		[SubscriptionPriceIDs.PRO_PLUS_YEARLY]: "pro_plus_yearly",
-		[SubscriptionPriceIDs.MAX_MONTHLY]: "max_monthly",
-		[SubscriptionPriceIDs.MAX_YEARLY]: "max_yearly"
-	};
-	return mapping[priceId] || null;
-}
-
-/**
  * Summary step handlers
  */
 function setupSummary(): void {
@@ -1160,7 +1150,7 @@ function setupSummary(): void {
 		"click",
 		() =>
 			void (async () => {
-				const selectedPriceId = onboardingService.getSelectedPriceId();
+				const selectedPurchaseType = onboardingService.getSelectedPurchaseType();
 
 				// Apply theme settings from onboarding state before everything else
 				applyThemeSettings();
@@ -1173,20 +1163,14 @@ function setupSummary(): void {
 				}
 
 				// Subscription flow - redirect to Stripe checkout
-				if (selectedPriceId) {
+				if (selectedPurchaseType) {
 					try {
 						summaryFinishButton!.disabled = true;
 						summaryFinishButton!.textContent = "Redirecting...";
 
-						// Determine purchase type based on price ID
-						const purchaseType = getPurchaseTypeFromPriceId(selectedPriceId);
-						if (!purchaseType) {
-							throw new Error("Invalid price ID");
-						}
-
 						const { data, error } = await supabaseService.supabase.functions.invoke("stripe", {
 							method: "POST",
-							body: JSON.stringify({ purchaseType })
+							body: JSON.stringify({ purchaseType: selectedPurchaseType })
 						});
 
 						if (error) {
@@ -1296,10 +1280,10 @@ function navigateToChatTab(): void {
  * Render summary step based on whether subscription was selected
  */
 function renderSummary(): void {
-	const selectedPriceId = onboardingService.getSelectedPriceId();
-	const selectedSubscriptionSummary = getSubscriptionSummaryFromPriceId(selectedPriceId);
+	const selectedPurchaseType = onboardingService.getSelectedPurchaseType();
+	const selectedSubscriptionSummary = getSubscriptionSummaryFromPurchaseType(selectedPurchaseType);
 
-	if (selectedPriceId) {
+	if (selectedPurchaseType) {
 		// Subscription flow
 		summaryApiKeyContent!.classList.add("hidden");
 		summarySubscriptionContent!.classList.remove("hidden");

--- a/src/index.html
+++ b/src/index.html
@@ -2194,7 +2194,7 @@ Your Max plan no longer has a monthly usage limit.</textarea
 										</div>
 										<div class="subscription-stat">
 											<span class="subscription-stat-label">Image Credits</span>
-											<strong>500 / month</strong>
+											<strong>200 / month</strong>
 										</div>
 									</div>
 

--- a/src/services/Onboarding.service.ts
+++ b/src/services/Onboarding.service.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ColorTheme, ThemeMode, ThemePreference } from "../types/Theme";
+import type { SubscriptionPurchaseType } from "../types/Price";
 import type {
 	OnboardingPath,
 	OnboardingPendingCredentials,
@@ -21,7 +22,7 @@ let currentState: OnboardingState = {
 	registrationCompleted: false,
 	setupOption: null,
 	pendingCredentials: null,
-	selectedPriceId: null
+	selectedPurchaseType: null
 };
 
 const onboardingOverlay = document.querySelector<HTMLDivElement>("#onboarding-overlay");
@@ -52,7 +53,7 @@ export function show(): void {
 		registrationCompleted: false,
 		setupOption: null,
 		pendingCredentials: null,
-		selectedPriceId: null
+		selectedPurchaseType: null
 	};
 
 	getOverlay().classList.remove("hidden");
@@ -141,12 +142,12 @@ export function getPendingCredentials(): OnboardingPendingCredentials | null {
 	return currentState.pendingCredentials ? { ...currentState.pendingCredentials } : null;
 }
 
-export function setSelectedPriceId(priceId: string | null): void {
-	currentState.selectedPriceId = priceId;
+export function setSelectedPurchaseType(purchaseType: SubscriptionPurchaseType | null): void {
+	currentState.selectedPurchaseType = purchaseType;
 }
 
-export function getSelectedPriceId(): string | null {
-	return currentState.selectedPriceId;
+export function getSelectedPurchaseType(): SubscriptionPurchaseType | null {
+	return currentState.selectedPurchaseType;
 }
 
 export function setSelectedTheme(theme: ColorTheme): void {

--- a/src/services/Supabase.service.ts
+++ b/src/services/Supabase.service.ts
@@ -1,7 +1,7 @@
 import type { Session, User as SupabaseUser } from "@supabase/supabase-js";
 import { createClient } from "@supabase/supabase-js";
 import type { User } from "../types/User";
-import { SubscriptionPriceIDs, SubscriptionPriceIDsOld } from "../types/Price";
+import { LEGACY_SUBSCRIPTION_PRICE_IDS } from "../types/Price";
 import type { ImageGenerationPermitted } from "../types/ImageGenerationTypes";
 import { danger, warn } from "./Toast.service";
 import type {
@@ -354,7 +354,9 @@ export async function getUserSubscription(session?: Session): Promise<UserSubscr
 	if (!currentUser) return null;
 	const { data, error } = await supabase
 		.from("user_subscriptions")
-		.select("user_id,status,price_id,current_period_end,cancel_at_period_end,stripe_customer_id")
+		.select(
+			"user_id,status,price_id,tier,billing_interval,stripe_account,current_period_end,cancel_at_period_end,stripe_customer_id"
+		)
 		.eq("user_id", currentUser.id)
 		.order("current_period_end", { ascending: false })
 		.limit(1)
@@ -456,34 +458,15 @@ export function getSubscriptionTier(sub: UserSubscription | null): SubscriptionT
 	if (["canceled", "incomplete_expired", "unpaid"].includes(String(sub.status))) {
 		return "free";
 	}
-	switch (sub.price_id) {
-		case "price_1S0heGGiJrKwXclR69Ku7XEc": //legacy 29.99 oldstripe
-		case "price_1SDf2NGiJrKwXclRwDs7XOd0": //legacy oldstripe
-		case SubscriptionPriceIDsOld.MAX_MONTHLY:
-		case SubscriptionPriceIDsOld.MAX_YEARLY:
-		case SubscriptionPriceIDs.MAX_MONTHLY:
-		case SubscriptionPriceIDs.MAX_YEARLY:
-			return "max";
-		case SubscriptionPriceIDs.PRO_PLUS_MONTHLY:
-		case SubscriptionPriceIDs.PRO_PLUS_YEARLY:
-			return "pro_plus";
-		case "price_1S0hdiGiJrKwXclRByeNLSPu": //legacy 14.99 oldstripe
-		case "price_1SDdbKGiJrKwXclR7hn7fF4s": //legacy oldstripe
-		case SubscriptionPriceIDsOld.PRO_MONTHLY:
-		case SubscriptionPriceIDsOld.PRO_YEARLY:
-		case SubscriptionPriceIDs.PRO_MONTHLY:
-		case SubscriptionPriceIDs.PRO_YEARLY:
-			return "pro";
-		default:
-			return "free";
+	if (sub.tier === "pro" || sub.tier === "pro_plus" || sub.tier === "max") {
+		return sub.tier;
 	}
-}
-
-export function getBillingPortalUrlWithEmail(email: string | null): string {
-	const base = "https://billing.stripe.com/p/login/5kQ8wQfgzcX6bfP8hNb7y00";
-	if (!email) return base;
-	const param = encodeURIComponent(email);
-	return `${base}?prefilled_email=${param}`;
+	if (sub.price_id && (LEGACY_SUBSCRIPTION_PRICE_IDS.max as readonly string[]).includes(sub.price_id)) return "max";
+	if (sub.price_id && (LEGACY_SUBSCRIPTION_PRICE_IDS.pro_plus as readonly string[]).includes(sub.price_id)) {
+		return "pro_plus";
+	}
+	if (sub.price_id && (LEGACY_SUBSCRIPTION_PRICE_IDS.pro as readonly string[]).includes(sub.price_id)) return "pro";
+	return "free";
 }
 
 export async function openCustomerPortal(): Promise<void> {
@@ -551,7 +534,7 @@ export async function updateSubscriptionUI(
 						: "—";
 		}
 		if (manageBtn) {
-			if (tier === "free") {
+			if (tier === "free" || sub?.stripe_account === "manual") {
 				manageBtn.classList.add("hidden");
 				manageBtn.onclick = null;
 			} else {

--- a/src/types/Onboarding.ts
+++ b/src/types/Onboarding.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ColorTheme, ThemeMode, ThemePreference } from "./Theme";
+import type { SubscriptionPurchaseType } from "./Price";
 
 export enum OnboardingPath {
 	EASY = "easy",
@@ -42,5 +43,5 @@ export interface OnboardingState {
 	registrationCompleted: boolean;
 	setupOption: OnboardingSetupOption;
 	pendingCredentials: OnboardingPendingCredentials | null;
-	selectedPriceId: string | null;
+	selectedPurchaseType: SubscriptionPurchaseType | null;
 }

--- a/src/types/Price.ts
+++ b/src/types/Price.ts
@@ -1,21 +1,27 @@
-//oldstripe
-export enum SubscriptionPriceIDsOld {
-	//PRO
-	PRO_MONTHLY = "price_1SDdbKGiJrKwXclR7hn7fF4s",
-	PRO_YEARLY = "price_1SDeIFGiJrKwXclRCNThnoXH",
-	//MAX
-	MAX_MONTHLY = "price_1SDf2NGiJrKwXclRwDs7XOd0",
-	MAX_YEARLY = "price_1SDf2rGiJrKwXclReGeg8fQo"
-}
-//newstripe
-export enum SubscriptionPriceIDs {
-	//PRO
-	PRO_MONTHLY = "price_1SOU2lKcI9PDo3JBhsT8URS9",
-	PRO_YEARLY = "price_1T9CqjKcI9PDo3JBP6613Pzh",
-	//PRO PLUS
-	PRO_PLUS_MONTHLY = "price_1T9CqqKcI9PDo3JBBGC59S8O",
-	PRO_PLUS_YEARLY = "price_1T9CqqKcI9PDo3JB7LXgL5MV",
-	//MAX
-	MAX_MONTHLY = "price_1T9DCYKcI9PDo3JBsFc4nlZa",
-	MAX_YEARLY = "price_1T9CqkKcI9PDo3JBEqHYJU68"
-}
+export type SubscriptionPurchaseType =
+	| "pro_monthly"
+	| "pro_yearly"
+	| "pro_plus_monthly"
+	| "pro_plus_yearly"
+	| "max_monthly"
+	| "max_yearly";
+
+// Compatibility aliases for rows written before Stripe Product metadata became
+// the primary tier source. New Stripe accounts do not belong in frontend code.
+export const LEGACY_SUBSCRIPTION_PRICE_IDS = {
+	pro: [
+		"price_1S0hdiGiJrKwXclRByeNLSPu",
+		"price_1SDdbKGiJrKwXclR7hn7fF4s",
+		"price_1SDeIFGiJrKwXclRCNThnoXH",
+		"price_1SOU2lKcI9PDo3JBhsT8URS9",
+		"price_1T9CqjKcI9PDo3JBP6613Pzh"
+	],
+	pro_plus: ["price_1T9CqqKcI9PDo3JBBGC59S8O", "price_1T9CqqKcI9PDo3JB7LXgL5MV"],
+	max: [
+		"price_1S0heGGiJrKwXclR69Ku7XEc",
+		"price_1SDf2NGiJrKwXclRwDs7XOd0",
+		"price_1SDf2rGiJrKwXclReGeg8fQo",
+		"price_1T9DCYKcI9PDo3JBsFc4nlZa",
+		"price_1T9CqkKcI9PDo3JBEqHYJU68"
+	]
+} as const;

--- a/src/types/Supabase.ts
+++ b/src/types/Supabase.ts
@@ -5,6 +5,9 @@ export interface UserSubscription {
 	user_id: string;
 	status: string;
 	price_id: string | null;
+	tier?: Exclude<SubscriptionTier, "free" | "canceled"> | null;
+	billing_interval?: "month" | "year" | null;
+	stripe_account?: "ysa-prod" | "zozoai-prod" | "manual" | null;
 	current_period_end?: string | number | null;
 	cancel_at_period_end?: boolean | null;
 	stripe_customer_id?: string | null;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -459,7 +459,7 @@ export type Database = {
 					created_at: string;
 					granted_image_generations: number;
 					remaining_image_generations: number;
-					source_price_id: Database["public"]["Enums"]["subscription_tier"] | null;
+					source_price_id: string | null;
 					updated_at: string;
 					user_id: string;
 				};
@@ -469,7 +469,7 @@ export type Database = {
 					created_at?: string;
 					granted_image_generations?: number;
 					remaining_image_generations?: number;
-					source_price_id?: Database["public"]["Enums"]["subscription_tier"] | null;
+					source_price_id?: string | null;
 					updated_at?: string;
 					user_id: string;
 				};
@@ -479,7 +479,7 @@ export type Database = {
 					created_at?: string;
 					granted_image_generations?: number;
 					remaining_image_generations?: number;
-					source_price_id?: Database["public"]["Enums"]["subscription_tier"] | null;
+					source_price_id?: string | null;
 					updated_at?: string;
 					user_id?: string;
 				};
@@ -562,7 +562,7 @@ export type Database = {
 					created_at: string;
 					granted_mega_credits: number;
 					remaining_mega_credits: number;
-					source_price_id: Database["public"]["Enums"]["subscription_tier"] | null;
+					source_price_id: string | null;
 					updated_at: string;
 					user_id: string;
 				};
@@ -572,7 +572,7 @@ export type Database = {
 					created_at?: string;
 					granted_mega_credits?: number;
 					remaining_mega_credits?: number;
-					source_price_id?: Database["public"]["Enums"]["subscription_tier"] | null;
+					source_price_id?: string | null;
 					updated_at?: string;
 					user_id: string;
 				};
@@ -582,7 +582,7 @@ export type Database = {
 					created_at?: string;
 					granted_mega_credits?: number;
 					remaining_mega_credits?: number;
-					source_price_id?: Database["public"]["Enums"]["subscription_tier"] | null;
+					source_price_id?: string | null;
 					updated_at?: string;
 					user_id?: string;
 				};
@@ -983,38 +983,47 @@ export type Database = {
 			};
 			user_subscriptions: {
 				Row: {
+					billing_interval: string | null;
 					cancel_at_period_end: boolean | null;
 					created_at: string;
 					current_period_end: string | null;
-					price_id: Database["public"]["Enums"]["subscription_tier"] | null;
+					price_id: string | null;
 					remaining_image_generations: number;
 					status: string;
 					stripe_customer_id: string | null;
+					stripe_account: string;
 					stripe_subscription_id: string | null;
+					tier: string | null;
 					updated_at: string;
 					user_id: string;
 				};
 				Insert: {
+					billing_interval?: string | null;
 					cancel_at_period_end?: boolean | null;
 					created_at?: string;
 					current_period_end?: string | null;
-					price_id?: Database["public"]["Enums"]["subscription_tier"] | null;
+					price_id?: string | null;
 					remaining_image_generations?: number;
 					status: string;
 					stripe_customer_id?: string | null;
+					stripe_account?: string;
 					stripe_subscription_id?: string | null;
+					tier?: string | null;
 					updated_at?: string;
 					user_id: string;
 				};
 				Update: {
+					billing_interval?: string | null;
 					cancel_at_period_end?: boolean | null;
 					created_at?: string;
 					current_period_end?: string | null;
-					price_id?: Database["public"]["Enums"]["subscription_tier"] | null;
+					price_id?: string | null;
 					remaining_image_generations?: number;
 					status?: string;
 					stripe_customer_id?: string | null;
+					stripe_account?: string;
 					stripe_subscription_id?: string | null;
+					tier?: string | null;
 					updated_at?: string;
 					user_id?: string;
 				};
@@ -1276,14 +1285,16 @@ export type Database = {
 					remaining_mega_credits: number | null;
 					remaining_purchased_image_gens: number | null;
 					remaining_subscription_image_gens: number | null;
+					stripe_account: string | null;
 					stripe_customer_id: string | null;
 					stripe_subscription_id: string | null;
 					subscription_cancel_at_period_end: boolean | null;
 					subscription_created_at: string | null;
 					subscription_current_period_end: string | null;
 					subscription_status: string | null;
-					subscription_tier: Database["public"]["Enums"]["subscription_tier"] | null;
+					subscription_tier: string | null;
 					subscription_updated_at: string | null;
+					tier: string | null;
 					sync_storage_quota_bytes: number | null;
 					sync_storage_used_bytes: number | null;
 					total_bucket_storage_bytes: number | null;

--- a/tests/e2e/messages/cloud-sync-quota.spec.ts
+++ b/tests/e2e/messages/cloud-sync-quota.spec.ts
@@ -4,7 +4,7 @@ import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
 
 const SUPABASE_HOST = "hglcltvwunzynnzduauy.supabase.co";
 const TEST_USER_ID = "00000000-0000-4000-8000-000000000152";
-const PRO_MONTHLY_PRICE_ID = "price_1SOU2lKcI9PDo3JBhsT8URS9";
+const PRO_MONTHLY_PRICE_ID = "price_from_future_stripe_account";
 
 function jsonResponse(body: unknown, status = 200) {
 	return {
@@ -68,6 +68,9 @@ async function stubSupabaseQuotaFull(page: Page): Promise<void> {
 					user_id: TEST_USER_ID,
 					status: "active",
 					price_id: PRO_MONTHLY_PRICE_ID,
+					tier: "pro",
+					billing_interval: "month",
+					stripe_account: "zozoai-prod",
 					current_period_end: "2026-12-31T00:00:00.000Z",
 					cancel_at_period_end: false,
 					stripe_customer_id: "cus_quota_playwright"

--- a/tests/integration/services/supabase-auth-refresh.test.ts
+++ b/tests/integration/services/supabase-auth-refresh.test.ts
@@ -174,4 +174,32 @@ describe("Supabase auth refresh handling", () => {
 			})
 		);
 	});
+
+	it("uses the normalized Stripe Product tier before legacy Price aliases", async () => {
+		const { getSubscriptionTier } = await import("../../../src/services/Supabase.service");
+
+		expect(
+			getSubscriptionTier({
+				id: "sub-target",
+				user_id: "user-1",
+				status: "active",
+				price_id: "price_from_future_stripe_account",
+				tier: "pro_plus",
+				stripe_account: "zozoai-prod"
+			})
+		).toBe("pro_plus");
+	});
+
+	it("keeps legacy Price aliases as a rollout fallback", async () => {
+		const { getSubscriptionTier } = await import("../../../src/services/Supabase.service");
+
+		expect(
+			getSubscriptionTier({
+				id: "sub-source",
+				user_id: "user-1",
+				status: "active",
+				price_id: "price_1T9DCYKcI9PDo3JBsFc4nlZa"
+			})
+		).toBe("max");
+	});
 });


### PR DESCRIPTION
## Summary
- read the normalized subscription `tier`, `billing_interval`, and `stripe_account` fields introduced by faetalize/zozo-edge#50
- remove active Stripe Price IDs from onboarding and Checkout state; the frontend now sends the existing purchase-type/lookup-key strings directly
- keep old Price IDs in one compatibility map only for rows written before the backend migration
- hide Stripe management for manual subscription rows
- correct the displayed Pro Plus Image Credit allowance from 500 to 200
- update generated database types for text Price IDs and the new subscription columns

## Deployment order
Merge and deploy faetalize/zozo-edge#50 first. That backend migration backfills normalized tiers and remains compatible with the currently deployed frontend. This frontend can then deploy without changing which Stripe account receives traffic.

## Verification
- `npm run lint`
- `npm run test` — 25 files, 127 tests
- `npm run build`
- targeted Playwright cloud-sync quota scenario
- Prettier check on every changed file

## Test scope
The new integration assertions cover normalized destination tiers and legacy fallback. The Playwright cloud-sync fixture uses a synthetic future-account Price ID plus normalized tier/account fields, so the cloud-sync path is explicitly covered without a live Supabase dependency.