### PR TITLE
Guide Zodiac users through the move to Zozo Chat

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -13,6 +13,10 @@ on:
             - unlabeled
     workflow_dispatch:
 
+concurrency:
+    group: merge-gate-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     verify:
         runs-on: ubuntu-latest

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,14 +16,32 @@ export default defineConfig({
 	projects: [
 		{
 			name: "chromium",
+			testIgnore: "**/dev-*.spec.ts",
 			use: { ...devices["Desktop Chrome"] }
+		},
+		{
+			name: "development",
+			testMatch: "**/dev-*.spec.ts",
+			use: { ...devices["Desktop Chrome"], baseURL: "https://127.0.0.1:4175" }
 		}
 	],
-	webServer: {
-		command: "npm run dev -- --host 127.0.0.1 --port 4173",
-		url: "https://127.0.0.1:4173",
-		ignoreHTTPSErrors: true,
-		reuseExistingServer: !process.env.CI,
-		timeout: 120_000
-	}
+	webServer: [
+		{
+			command: "npm run dev -- --config vite.e2e.config.mts --host 127.0.0.1 --port 4173",
+			// Exercise production flags while retaining Vite's module endpoints for fixtures.
+			env: { NODE_ENV: "production" },
+			url: "https://127.0.0.1:4173",
+			ignoreHTTPSErrors: true,
+			reuseExistingServer: false,
+			timeout: 120_000
+		},
+		{
+			command: "npm run dev -- --config vite.e2e.config.mts --host 127.0.0.1 --port 4175",
+			env: { NODE_ENV: "development" },
+			url: "https://127.0.0.1:4175",
+			ignoreHTTPSErrors: true,
+			reuseExistingServer: false,
+			timeout: 120_000
+		}
+	]
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,39 @@
+import { themeService } from "./services/Theme.service";
+import * as personalityService from "./services/Personality.service";
+import * as settingsService from "./services/Settings.service";
+import * as overlayService from "./services/Overlay.service";
+import * as chatsService from "./services/Chats.service";
+import * as onboardingService from "./services/Onboarding.service";
+import * as syncService from "./services/Sync.service";
+
+//load all component code
+//eager ensures the modules execute at startup (no async race / ordering surprises)
+const components = import.meta.glob("./components/static/*.ts", { eager: true });
+void components;
+
+export async function initializeApp(options: { deferOnboarding?: boolean } = {}): Promise<void> {
+	// Initialize theme service first (before DOM is fully rendered)
+	themeService.initialize();
+
+	// Initialize in the correct order
+	settingsService.initialize();
+
+	// Initialize database
+	await chatsService.initialize();
+	await personalityService.initialize();
+	personalityService.initSyncModalHandlers();
+	personalityService.initAddPersonaModalHandlers();
+
+	// Initialize cloud sync (attaches Dexie hooks + online/offline listeners)
+	syncService.initialize();
+
+	//event listeners
+	const hideOverlayButton = document.querySelector("#btn-hide-overlay");
+	hideOverlayButton?.addEventListener("click", () => overlayService.closeOverlay());
+
+	// Check if onboarding should show on first run
+	if (!options.deferOnboarding && (await onboardingService.shouldShowOnboarding())) {
+		onboardingService.show();
+	}
+	document.querySelector("#main-container")?.setAttribute("aria-busy", "false");
+}

--- a/src/components/static/AdaptiveSheet.component.ts
+++ b/src/components/static/AdaptiveSheet.component.ts
@@ -98,7 +98,7 @@ function resetSheetPosition(sheet: HTMLElement): void {
 }
 
 function beginDrag(sheet: HTMLElement, handle: HTMLElement, clientY: number, pointerId?: number): void {
-	if (!adaptiveSheetMediaQuery.matches || dragState) return;
+	if (!adaptiveSheetMediaQuery.matches || dragState || sheet.dataset.surfaceBusy === "true") return;
 
 	dragState = {
 		sheet,

--- a/src/components/static/CloudSync.component.ts
+++ b/src/components/static/CloudSync.component.ts
@@ -22,6 +22,7 @@ import type { SyncStatus } from "../../events";
 import { info, danger } from "../../services/Toast.service";
 import { confirmDialog, confirmDialogDanger } from "../../utils/helpers";
 import { getSubscriptionTier } from "../../services/Supabase.service";
+import { startupPresentation } from "../../services/StartupPresentation.service";
 
 // ── DOM Elements ───────────────────────────────────────────────────────────
 
@@ -604,6 +605,7 @@ onAppEvent(
 	(event) =>
 		void (async () => {
 			const { loggedIn, subscription, session } = event.detail;
+			if (startupPresentation.migrationActive) await startupPresentation.ready;
 
 			if (!loggedIn) {
 				// Hide sync section, reset state

--- a/src/components/static/DataTakeout.component.ts
+++ b/src/components/static/DataTakeout.component.ts
@@ -223,12 +223,18 @@ function formatImportResult(result: takeoutService.TakeoutImportResult): string 
 
 async function refreshImportDestinations(): Promise<void> {
 	importStatus.textContent = "Checking restore destinations…";
+	for (const destination of [localDestination, cloudDestination]) {
+		destination.dataset.available = "false";
+		destination.disabled = true;
+		destination.checked = false;
+	}
+	prepareCloudButton.classList.add("hidden");
 	try {
 		const destinations = await takeoutService.getTakeoutImportDestinations();
 		localDestination.dataset.available = String(destinations.local.available);
 		cloudDestination.dataset.available = String(destinations.cloud.available);
-		localDestination.disabled = !destinations.local.available;
-		cloudDestination.disabled = !destinations.cloud.available;
+		localDestination.disabled = importBusy || !destinations.local.available;
+		cloudDestination.disabled = importBusy || !destinations.cloud.available;
 		localDestinationNote.textContent = destinations.local.available
 			? "Local IndexedDB and settings"
 			: destinations.local.reason || "Unavailable";

--- a/src/components/static/DataTakeout.component.ts
+++ b/src/components/static/DataTakeout.component.ts
@@ -1,6 +1,11 @@
 import { DEFAULT_TAKEOUT_CATEGORIES } from "../../constants/Takeout";
 import { dispatchAppEvent, onAppEvent } from "../../events";
-import type { TakeoutCategory, TakeoutConflictResolution, TakeoutDestination } from "../../types/Takeout";
+import type {
+	TakeoutCategory,
+	TakeoutConflictResolution,
+	TakeoutDestination,
+	TakeoutSource
+} from "../../types/Takeout";
 import * as takeoutService from "../../services/Takeout.service";
 import * as surfaceService from "../../services/Surface.service";
 import * as syncService from "../../services/Sync.service";
@@ -50,12 +55,52 @@ let pendingInspection: takeoutService.TakeoutImportInspection | null = null;
 let sensitiveImportConfirmed = false;
 let exportAbortController: AbortController | null = null;
 
+interface ExportSheetOptions {
+	categories?: readonly TakeoutCategory[];
+	source?: TakeoutSource;
+	onDownloadInitiated?: (result: takeoutService.BuildTakeoutExportResult) => void;
+	onClose?: () => void;
+}
+let exportOptions: ExportSheetOptions = {};
+let importOnClose: (() => void) | undefined;
+
+export function openTakeoutExport(options: ExportSheetOptions = {}): void {
+	if (exportBusy) return;
+	exportOptions = options;
+	resetExportSheet();
+	prepareTakeoutSheet(exportSheet);
+	surfaceService.show(exportSheet.id);
+}
+
+export function openTakeoutImport(options: { instructions?: string; onClose?: () => void } = {}): void {
+	if (importBusy) return;
+	importOnClose = options.onClose;
+	resetImportSheet();
+	must("#takeout-import-instructions").textContent =
+		options.instructions ?? "Restore a Zozo Chat takeout or supported legacy chat and persona files.";
+	prepareTakeoutSheet(importSheet);
+	surfaceService.show(importSheet.id);
+	void refreshImportDestinations();
+}
+
+exportSheet.addEventListener("surface-closed", () => {
+	const onClose = exportOptions.onClose;
+	exportOptions = {};
+	if (onClose) queueMicrotask(onClose);
+});
+importSheet.addEventListener("surface-closed", () => {
+	const onClose = importOnClose;
+	importOnClose = undefined;
+	if (onClose) queueMicrotask(onClose);
+});
+
 function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
 	return `${count} ${count === 1 ? singular : pluralForm}`;
 }
 
 function setExportBusy(busy: boolean): void {
 	exportBusy = busy;
+	exportSheet.dataset.surfaceBusy = String(busy);
 	exportButton.disabled = busy;
 	exportCloseButton.disabled = busy;
 	exportCancelButton.classList.toggle("hidden", !busy);
@@ -68,6 +113,7 @@ function setExportBusy(busy: boolean): void {
 
 function setImportBusy(busy: boolean): void {
 	importBusy = busy;
+	importSheet.dataset.surfaceBusy = String(busy);
 	importButton.disabled = busy;
 	importCloseButton.disabled = busy;
 	importFiles.disabled = busy;
@@ -92,14 +138,19 @@ function refreshCategoryState(): void {
 }
 
 function resetExportSheet(): void {
-	const defaults = new Set(DEFAULT_TAKEOUT_CATEGORIES);
+	const defaults = new Set(exportOptions.categories ?? DEFAULT_TAKEOUT_CATEGORIES);
 	categoryInputs.forEach((input) => {
 		input.checked = defaults.has(input.value as TakeoutCategory);
 	});
 	exportStatus.textContent = "";
 	setExportBusy(false);
 	refreshCategoryState();
-	const source = syncService.isOnlineSyncEnabled() ? "Cloud Sync" : "this browser";
+	const source =
+		exportOptions.source === "local"
+			? "this browser"
+			: syncService.isOnlineSyncEnabled()
+				? "Cloud Sync"
+				: "this browser";
 	exportSource.textContent = `Authoritative source: ${source}.`;
 }
 
@@ -210,9 +261,11 @@ async function createExport(): Promise<void> {
 		const result = await takeoutService.buildTakeoutExport(
 			categories,
 			(progress) => updateProgress(exportStatus, progress),
-			exportAbortController.signal
+			exportAbortController.signal,
+			exportOptions.source
 		);
 		takeoutService.downloadTakeout(result.document, result.filename);
+		exportOptions.onDownloadInitiated?.(result);
 		const summary = formatExportResult(result);
 		transitionSheetHeight(exportSheet, () => {
 			exportStatus.textContent = summary;
@@ -326,17 +379,8 @@ selectAll.addEventListener("change", () => {
 });
 categoryInputs.forEach((input) => input.addEventListener("change", refreshCategoryState));
 
-openExportButton.addEventListener("click", () => {
-	resetExportSheet();
-	prepareTakeoutSheet(exportSheet);
-	surfaceService.show(exportSheet.id);
-});
-openImportButton.addEventListener("click", () => {
-	resetImportSheet();
-	prepareTakeoutSheet(importSheet);
-	surfaceService.show(importSheet.id);
-	void refreshImportDestinations();
-});
+openExportButton.addEventListener("click", () => openTakeoutExport());
+openImportButton.addEventListener("click", () => openTakeoutImport());
 exportButton.addEventListener("click", () => void createExport());
 exportCancelButton.addEventListener("click", () => exportAbortController?.abort());
 exportCloseButton.addEventListener("click", () => surfaceService.close(exportSheet.id));

--- a/src/components/static/DebugAnnouncement.component.ts
+++ b/src/components/static/DebugAnnouncement.component.ts
@@ -28,7 +28,7 @@ if (
 
 const actionSelect = actionInput;
 const actionLabel = actionLabelInput;
-const isLocalhost = ["localhost", "127.0.0.1", "::1", "192.168.1.1"].includes(window.location.hostname);
+const isDev = import.meta.env.DEV;
 
 function updateActionLabelState(): void {
 	const hasAction = actionSelect.value === "dismiss" || actionSelect.value === "next";
@@ -36,7 +36,7 @@ function updateActionLabelState(): void {
 	actionLabel.required = hasAction;
 }
 
-if (isLocalhost) {
+if (isDev) {
 	openButton.addEventListener("click", () => {
 		overlayService.show("form-debug-announcement");
 		updateActionLabelState();

--- a/src/components/static/DebugButtons.component.ts
+++ b/src/components/static/DebugButtons.component.ts
@@ -38,16 +38,16 @@ if (
 	throw new Error("DebugButtons component is not properly initialized.");
 }
 
-// Only enable debug UI when running on localhost
-const isLocalhost = ["localhost", "127.0.0.1", "::1", "192.168.1.1"].includes(window.location.hostname);
+// Debug controls follow the build mode, including dev servers on LAN addresses.
+const isDev = import.meta.env.DEV;
 
-if (!isLocalhost) {
-	// Hide debug UI entirely in non-local environments
+if (!isDev) {
+	// Hide debug UI in production builds.
 	if (debugSection) {
 		debugSection.classList.add("hidden");
 	}
 } else {
-	// Ensure required buttons exist in localhost
+	// Show debug controls in development.
 	if (debugSection) {
 		debugSection.classList.remove("hidden");
 	}
@@ -103,7 +103,7 @@ const modelMessages = [
 ];
 
 // Register listeners only in localhost
-if (isLocalhost && generateRandomChatsButton)
+if (isDev && generateRandomChatsButton)
 	generateRandomChatsButton.addEventListener(
 		"click",
 		() =>
@@ -219,7 +219,7 @@ const toneExampleSets = [
 	["What an intriguing possibility!", "Let's explore uncharted territory...", "Adventure awaits in this concept!"]
 ];
 
-if (isLocalhost && generateRandomPersonalitiesButton)
+if (isDev && generateRandomPersonalitiesButton)
 	generateRandomPersonalitiesButton.addEventListener(
 		"click",
 		() =>
@@ -250,7 +250,7 @@ if (isLocalhost && generateRandomPersonalitiesButton)
 			})()
 	);
 
-if (isLocalhost && generateLongChatButton)
+if (isDev && generateLongChatButton)
 	generateLongChatButton.addEventListener(
 		"click",
 		() =>
@@ -271,7 +271,7 @@ if (isLocalhost && generateLongChatButton)
 			})()
 	);
 
-if (isLocalhost && generateMediumChatButton)
+if (isDev && generateMediumChatButton)
 	generateMediumChatButton.addEventListener(
 		"click",
 		() =>
@@ -293,7 +293,7 @@ if (isLocalhost && generateMediumChatButton)
 	);
 
 // Toast testing buttons
-if (isLocalhost && testToastNormalButton)
+if (isDev && testToastNormalButton)
 	testToastNormalButton.addEventListener("click", () => {
 		toastService.info({
 			title: "Info Toast",
@@ -301,7 +301,7 @@ if (isLocalhost && testToastNormalButton)
 		});
 	});
 
-if (isLocalhost && testToastWarningButton)
+if (isDev && testToastWarningButton)
 	testToastWarningButton.addEventListener("click", () => {
 		toastService.warn({
 			title: "Warning Toast",
@@ -309,7 +309,7 @@ if (isLocalhost && testToastWarningButton)
 		});
 	});
 
-if (isLocalhost && testToastDangerButton)
+if (isDev && testToastDangerButton)
 	testToastDangerButton.addEventListener("click", () => {
 		toastService.danger({
 			title: "Error Toast",
@@ -317,7 +317,7 @@ if (isLocalhost && testToastDangerButton)
 		});
 	});
 
-if (isLocalhost && testToastActionsButton)
+if (isDev && testToastActionsButton)
 	testToastActionsButton.addEventListener("click", () => {
 		toastService.show({
 			title: "Toast with Actions",
@@ -341,7 +341,7 @@ if (isLocalhost && testToastActionsButton)
 		});
 	});
 
-if (isLocalhost && testToastSpamButton)
+if (isDev && testToastSpamButton)
 	testToastSpamButton.addEventListener("click", () => {
 		// Test the 5-toast limit by creating 8 toasts rapidly
 		for (let i = 1; i <= 8; i++) {
@@ -356,12 +356,12 @@ if (isLocalhost && testToastSpamButton)
 		}
 	});
 
-if (isLocalhost && showSubscriptionOptionsButton)
+if (isDev && showSubscriptionOptionsButton)
 	showSubscriptionOptionsButton.addEventListener("click", () => {
 		overlayService.show("form-subscription");
 	});
 
-if (isLocalhost && testOnboardingButton)
+if (isDev && testOnboardingButton)
 	testOnboardingButton.addEventListener("click", () => {
 		onboardingService.show();
 	});

--- a/src/components/static/TargetedAnnouncement.component.ts
+++ b/src/components/static/TargetedAnnouncement.component.ts
@@ -91,7 +91,7 @@ let announcements: Announcement[] = debugAnnouncement ? [debugAnnouncement] : []
 function canPresent(): boolean {
 	return (
 		!startupPresentation.migrationActive &&
-		!document.querySelector("#surface-plane .surface-open") &&
+		!document.querySelector("#surface-plane .surface-plane__item:not(.hidden)") &&
 		overlay.classList.contains("hidden") &&
 		onboardingOverlay.classList.contains("hidden") &&
 		Array.from(appDialogs).every((dialog) => dialog.classList.contains("hidden"))
@@ -223,6 +223,9 @@ const overlayObserver = new MutationObserver(() => showNextAnnouncement());
 overlayObserver.observe(overlay, { attributes: true, attributeFilter: ["class"] });
 overlayObserver.observe(onboardingOverlay, { attributes: true, attributeFilter: ["class"] });
 appDialogs.forEach((dialog) => overlayObserver.observe(dialog, { attributes: true, attributeFilter: ["class"] }));
+
+// Capture the non-bubbling surface event, then allow any handoff to another dialog to finish.
+document.addEventListener("surface-closed", () => requestAnimationFrame(showNextAnnouncement), true);
 
 onAppEvent("sync-startup-settled", (event) => {
 	syncStartupSettledUserId = event.detail.userId;

--- a/src/components/static/TargetedAnnouncement.component.ts
+++ b/src/components/static/TargetedAnnouncement.component.ts
@@ -3,6 +3,7 @@ import { onAppEvent } from "../../events";
 import { getEligibleAnnouncements, recordAnnouncementReceipt } from "../../services/Announcement.service";
 import * as overlayService from "../../services/Overlay.service";
 import { getCurrentUser } from "../../services/Supabase.service";
+import { startupPresentation } from "../../services/StartupPresentation.service";
 
 const overlayElement = document.querySelector<HTMLElement>("#overlay");
 const onboardingOverlayElement = document.querySelector<HTMLElement>("#onboarding-overlay");
@@ -48,8 +49,7 @@ let appReady = false;
 let presentationPaused = false;
 
 function readDebugAnnouncement(): Announcement | null {
-	const isLocalhost = ["localhost", "127.0.0.1", "::1", "192.168.1.1"].includes(window.location.hostname);
-	if (!isLocalhost) return null;
+	if (!import.meta.env.DEV) return null;
 
 	const stored = localStorage.getItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
 	if (!stored) return null;
@@ -90,6 +90,8 @@ let announcements: Announcement[] = debugAnnouncement ? [debugAnnouncement] : []
 
 function canPresent(): boolean {
 	return (
+		!startupPresentation.migrationActive &&
+		!document.querySelector("#surface-plane .surface-open") &&
 		overlay.classList.contains("hidden") &&
 		onboardingOverlay.classList.contains("hidden") &&
 		Array.from(appDialogs).every((dialog) => dialog.classList.contains("hidden"))
@@ -247,6 +249,7 @@ onAppEvent("auth-state-changed", (event) => {
 });
 
 async function initializeAnnouncements(): Promise<void> {
+	if (startupPresentation.migrationActive) await startupPresentation.ready;
 	const user = await getCurrentUser();
 	appReady = true;
 	if (user) {

--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,7 @@
 			<span id="maintenance-banner-text"></span>
 		</div>
 
-		<div id="main-container">
+		<div id="main-container" aria-busy="true">
 			<div id="dialog" class="dialog hidden">
 				<div id="dialog-message"></div>
 				<div id="dialog-buttons" class="btn-array">
@@ -1077,7 +1077,7 @@
 								</a>
 							</div>
 						</div>
-						<div class="settings-list-item" id="debug-section">
+						<div class="settings-list-item hidden" id="debug-section">
 							<h3 class="debug">Debug</h3>
 							<div class="btn-array-vertical debug">
 								<button class="btn btn-primary" id="btn-debug-chats">Generate 10 Random Chats</button>
@@ -1105,6 +1105,9 @@
 									Open Subscription Options
 								</button>
 								<button class="btn btn-primary" id="btn-debug-onboarding">Test Onboarding</button>
+								<button class="btn btn-primary hidden" id="btn-debug-migration" type="button">
+									Test migration
+								</button>
 								<button class="btn btn-primary" id="btn-debug-announcement">
 									Compose Announcement Preview
 								</button>
@@ -3308,12 +3311,68 @@ Your Max plan no longer has a monthly usage limit.</textarea
 		</div>
 
 		<div id="surface-plane" class="surface-plane" aria-live="polite">
+			<section
+				id="domain-migration-sheet"
+				class="domain-migration-sheet hidden"
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="domain-migration-title"
+				aria-describedby="domain-migration-description"
+				data-trap-focus="true"
+				data-dismiss-on-escape="false"
+			>
+				<h1 id="domain-migration-title" tabindex="-1" data-surface-initial-focus>Zodiac is now Zozo</h1>
+				<p id="domain-migration-description">
+					And it has a new home at
+					<a
+						class="domain-migration-destination"
+						href="https://chat.zozo.sh"
+						target="_blank"
+						rel="noopener noreferrer"
+						>https://chat.zozo.sh</a
+					>
+				</p>
+				<p>Bring your data with you to ensure a smooth transition</p>
+				<p
+					id="domain-migration-status"
+					class="domain-migration-error hidden"
+					role="status"
+					aria-live="polite"
+				></p>
+				<button
+					id="btn-migration-export"
+					type="button"
+					class="btn btn-secondary hidden"
+					data-local-migration
+					disabled
+				>
+					Export data
+				</button>
+				<label class="domain-migration-acknowledgement hidden" data-local-migration>
+					<input id="migration-confirmed" type="checkbox" disabled />
+					<span id="migration-confirmation-label">I’m ready to continue</span>
+				</label>
+				<div class="domain-migration-actions">
+					<button
+						id="btn-migration-continue"
+						type="button"
+						class="btn btn-primary hidden"
+						data-local-migration
+						disabled
+						aria-describedby="migration-confirmation-label"
+					>
+						Continue to Zozo Chat
+					</button>
+					<button id="btn-migration-retry" type="button" class="btn btn-secondary hidden">Try again</button>
+				</div>
+			</section>
 			<div
 				id="takeout-export-sheet"
 				class="takeout-sheet hidden"
 				role="dialog"
 				aria-modal="true"
 				aria-labelledby="takeout-export-title"
+				data-trap-focus="true"
 			>
 				<div class="takeout-sheet__header">
 					<div>
@@ -3461,11 +3520,12 @@ Your Max plan no longer has a monthly usage limit.</textarea
 				role="dialog"
 				aria-modal="true"
 				aria-labelledby="takeout-import-title"
+				data-trap-focus="true"
 			>
 				<div class="takeout-sheet__header">
 					<div>
 						<h1 id="takeout-import-title">Import your data</h1>
-						<p class="takeout-sheet__subtitle">
+						<p id="takeout-import-instructions" class="takeout-sheet__subtitle">
 							Restore a Zozo Chat takeout or supported legacy chat and persona files.
 						</p>
 					</div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,36 +1,8 @@
-import { themeService } from "./services/Theme.service";
-import * as personalityService from "./services/Personality.service";
-import * as settingsService from "./services/Settings.service";
-import * as overlayService from "./services/Overlay.service";
-import * as chatsService from "./services/Chats.service";
-import * as onboardingService from "./services/Onboarding.service";
-import * as syncService from "./services/Sync.service";
+// Decide migration before eager components write defaults or open startup UI.
+const { initializeDomainMigration } = await import("./services/DomainMigration.service");
+await initializeDomainMigration(async (deferOnboarding) => {
+	const { initializeApp } = await import("./app");
+	await initializeApp({ deferOnboarding });
+});
 
-//load all component code
-//eager ensures the modules execute at startup (no async race / ordering surprises)
-const components = import.meta.glob("./components/static/*.ts", { eager: true });
-void components;
-
-// Initialize theme service first (before DOM is fully rendered)
-themeService.initialize();
-
-// Initialize in the correct order
-settingsService.initialize();
-
-// Initialize database
-await chatsService.initialize();
-await personalityService.initialize();
-personalityService.initSyncModalHandlers();
-personalityService.initAddPersonaModalHandlers();
-
-// Initialize cloud sync (attaches Dexie hooks + online/offline listeners)
-syncService.initialize();
-
-//event listeners
-const hideOverlayButton = document.querySelector("#btn-hide-overlay");
-hideOverlayButton?.addEventListener("click", () => overlayService.closeOverlay());
-
-// Check if onboarding should show on first run
-if (await onboardingService.shouldShowOnboarding()) {
-	onboardingService.show();
-}
+export {};

--- a/src/services/DomainMigration.service.ts
+++ b/src/services/DomainMigration.service.ts
@@ -1,0 +1,250 @@
+import { DEFAULT_TAKEOUT_CATEGORIES, TAKEOUT_SETTING_KEYS } from "../constants/Takeout";
+import { DEFAULT_IMAGE_EDIT_MODEL, DEFAULT_IMAGE_MODEL } from "../constants/ImageModels";
+import { SETTINGS_STORAGE_KEYS } from "../constants/SettingsStorageKeys";
+import { holdStartupPresentation, releaseStartupPresentation } from "./StartupPresentation.service";
+import * as surfaceService from "./Surface.service";
+
+const destination = import.meta.env.DEV ? window.location.origin : "https://chat.zozo.sh";
+const devArrivalStateKey = "zozo-dev-migration-arrived";
+const signalKey = "migration";
+type MigrationSignal = "takeout-v1" | "cloud" | "empty" | "continue";
+type StartApp = (deferOnboarding: boolean) => Promise<void>;
+
+interface LocalInventory {
+	chats: number;
+	personas: number;
+	preferences: boolean;
+	apiKeys: boolean;
+}
+
+function must<T extends HTMLElement>(id: string): T {
+	const element = document.getElementById(id);
+	if (!element) throw new Error(`Missing migration element: ${id}`);
+	return element as T;
+}
+
+// Only defaults written automatically by startup are excluded. Stored scalar
+// preferences otherwise represent a user choice, even when that choice is false.
+async function readLocalInventory(): Promise<LocalInventory> {
+	const { db } = await import("./Db.service");
+	const [chats, personas] = await Promise.all([db.chats.count(), db.personalities.count()]);
+	let preferences = false;
+	let apiKeys = false;
+	for (const [category, keys] of Object.entries(TAKEOUT_SETTING_KEYS)) {
+		for (const key of keys) {
+			const value = localStorage.getItem(key);
+			if (!value?.trim()) continue;
+			if (category === "apiKeys") {
+				apiKeys = true;
+				continue;
+			}
+			if (key === SETTINGS_STORAGE_KEYS.IMAGE_MODEL && value === DEFAULT_IMAGE_MODEL) continue;
+			if (key === SETTINGS_STORAGE_KEYS.IMAGE_EDIT_MODEL && value === DEFAULT_IMAGE_EDIT_MODEL) continue;
+			const isCollection =
+				category === "loras" ||
+				category === "pins" ||
+				[
+					SETTINGS_STORAGE_KEYS.ROLEPLAY_FAVORITE_ACTIONS,
+					SETTINGS_STORAGE_KEYS.ROLEPLAY_CUSTOM_CATEGORIES,
+					SETTINGS_STORAGE_KEYS.ROLEPLAY_CUSTOM_ACTIONS
+				].some((collectionKey) => collectionKey === key);
+			if (isCollection) {
+				const entries: unknown = JSON.parse(value);
+				if (!Array.isArray(entries)) throw new Error(`Unable to read saved ${category}.`);
+				if (entries.length === 0) continue;
+			}
+			preferences = true;
+		}
+	}
+	return { chats, personas, preferences, apiKeys };
+}
+
+async function hasEnabledCloudSync(signal: AbortSignal): Promise<boolean> {
+	// Loading the client alone does not start profile hydration or sync prompts.
+	const { supabase } = await import("./SupabaseClient");
+	const {
+		data: { session },
+		error: sessionError
+	} = await supabase.auth.getSession();
+	if (sessionError) throw new Error("Unable to check your sign-in — please reconnect and retry");
+	if (!session) return false;
+	const { data, error } = await supabase
+		.from("user_sync_preferences")
+		.select("sync_enabled")
+		.eq("user_id", session.user.id)
+		.abortSignal(signal)
+		.maybeSingle();
+	if (error) throw new Error("Unable to check whether Cloud Sync is enabled — please reconnect and retry");
+	if (data && typeof data.sync_enabled !== "boolean") throw new Error("Cloud Sync returned an invalid preference");
+	return data?.sync_enabled === true;
+}
+
+async function checkSource(): Promise<"cloud" | LocalInventory> {
+	const controller = new AbortController();
+	let timeout: number | undefined;
+	try {
+		return await Promise.race([
+			(async () => {
+				if (await hasEnabledCloudSync(controller.signal)) return "cloud" as const;
+				return await readLocalInventory();
+			})(),
+			new Promise<never>((_, reject) => {
+				timeout = window.setTimeout(() => {
+					controller.abort();
+					reject(
+						new Error("The data check took too long — reconnect or close other Zodiac tabs, then retry")
+					);
+				}, 15_000);
+			})
+		]);
+	} finally {
+		window.clearTimeout(timeout);
+	}
+}
+
+function navigate(signal: MigrationSignal): void {
+	// Dev keeps its exact origin (including protocol/port). Never forward the
+	// old path, query parameters, or auth material to either destination.
+	window.location.replace(`${destination}/?${signalKey}=${signal}`);
+}
+
+async function receiveMigration(startApp: StartApp, signal: MigrationSignal): Promise<void> {
+	if (signal === "takeout-v1") holdStartupPresentation();
+	await startApp(signal === "takeout-v1");
+	if (signal !== "takeout-v1") return;
+	const takeout = await import("../components/static/DataTakeout.component");
+	takeout.openTakeoutImport({
+		instructions: "Choose the file you exported from Zodiac",
+		onClose: releaseStartupPresentation
+	});
+}
+
+export async function initializeDomainMigration(startApp: StartApp): Promise<void> {
+	if (import.meta.env.DEV) {
+		const testMigration = must<HTMLButtonElement>("btn-debug-migration");
+		testMigration.classList.remove("hidden");
+		testMigration.onclick = () => {
+			const state = { ...window.history.state };
+			delete state[devArrivalStateKey];
+			window.history.replaceState(state, "", window.location.href);
+			window.location.reload();
+		};
+	}
+	if (import.meta.env.DEV || window.location.hostname === "chat.zozo.sh") {
+		const url = new URL(window.location.href);
+		const signal = url.searchParams.get(signalKey);
+		if (signal === "takeout-v1" || signal === "cloud" || signal === "empty" || signal === "continue") {
+			await receiveMigration(startApp, signal);
+			// Consume only after the importer has opened successfully. Preserve
+			// unrelated parameters and any auth hash on the destination itself.
+			url.searchParams.delete(signalKey);
+			window.history.replaceState(
+				import.meta.env.DEV ? { ...window.history.state, [devArrivalStateKey]: true } : window.history.state,
+				"",
+				url
+			);
+			if (!import.meta.env.DEV) return;
+		} else if (import.meta.env.DEV && window.history.state?.[devArrivalStateKey]) {
+			// On dev the two sides share an origin. Keep refreshes of this history
+			// entry on the arrival side after consuming the one-time URL signal.
+			await startApp(false);
+		}
+	}
+	if (import.meta.env.DEV && window.history.state?.[devArrivalStateKey]) {
+		return;
+	}
+	if (!import.meta.env.DEV && window.location.hostname !== "zodiac.faetalize.dev") {
+		await startApp(false);
+		return;
+	}
+
+	let appPromise: Promise<void> | undefined;
+	const loadApp = () =>
+		(appPromise ??= startApp(true).catch((error: unknown) => {
+			appPromise = undefined;
+			throw error;
+		}));
+	const sheet = must("domain-migration-sheet");
+	const status = must("domain-migration-status");
+	const exportButton = must<HTMLButtonElement>("btn-migration-export");
+	const continueButton = must<HTMLButtonElement>("btn-migration-continue");
+	const retryButton = must<HTMLButtonElement>("btn-migration-retry");
+	const confirmation = must<HTMLInputElement>("migration-confirmed");
+	const localContent = sheet.querySelectorAll<HTMLElement>("[data-local-migration]");
+	let checking = false;
+	let downloaded = false;
+
+	async function check(): Promise<void> {
+		if (checking) return;
+		let requiresInteraction = false;
+		checking = true;
+		confirmation.checked = false;
+		confirmation.disabled = true;
+		continueButton.disabled = true;
+		exportButton.disabled = true;
+		localContent.forEach((element) => element.classList.add("hidden"));
+		retryButton.classList.add("hidden");
+		status.textContent = "";
+		status.classList.add("hidden");
+		try {
+			const source = await checkSource();
+			if (source === "cloud") {
+				navigate("cloud");
+				return;
+			}
+			if (!source.chats && !source.personas && !source.preferences && !source.apiKeys) {
+				navigate("empty");
+				return;
+			}
+			await loadApp();
+			exportButton.disabled = false;
+			confirmation.disabled = false;
+			localContent.forEach((element) => element.classList.remove("hidden"));
+			requiresInteraction = true;
+		} catch (error) {
+			status.textContent = (error instanceof Error ? error.message : "Unable to check your local data").replace(
+				/\.+$/,
+				""
+			);
+			status.classList.remove("hidden");
+			retryButton.classList.remove("hidden");
+			requiresInteraction = true;
+		} finally {
+			checking = false;
+			// Redirect-only visits never mount a migration surface or change the
+			// theme. Present UI only when there is something for the user to do.
+			if (requiresInteraction) {
+				const { themeService } = await import("./Theme.service");
+				themeService.reloadFromStorage();
+				surfaceService.show(sheet.id);
+			}
+		}
+	}
+
+	confirmation.addEventListener("change", () => {
+		continueButton.disabled = !confirmation.checked;
+	});
+	continueButton.addEventListener("click", () => {
+		if (confirmation.checked) navigate(downloaded ? "takeout-v1" : "continue");
+	});
+	retryButton.addEventListener("click", () => {
+		void check();
+	});
+	exportButton.addEventListener("click", () => {
+		void (async () => {
+			const takeout = await import("../components/static/DataTakeout.component");
+			takeout.openTakeoutExport({
+				source: "local",
+				categories: DEFAULT_TAKEOUT_CATEGORIES,
+				onDownloadInitiated: () => {
+					downloaded = true;
+					status.textContent = "";
+					status.classList.add("hidden");
+				},
+				onClose: () => surfaceService.show(sheet.id)
+			});
+		})();
+	});
+	holdStartupPresentation();
+	await check();
+}

--- a/src/services/StartupPresentation.service.ts
+++ b/src/services/StartupPresentation.service.ts
@@ -1,0 +1,19 @@
+// A promise also handles components loaded after the decision has settled.
+let release: (() => void) | undefined;
+export const startupPresentation = {
+	migrationActive: false,
+	ready: Promise.resolve()
+};
+
+export function holdStartupPresentation(): void {
+	startupPresentation.migrationActive = true;
+	startupPresentation.ready = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+}
+
+export function releaseStartupPresentation(): void {
+	startupPresentation.migrationActive = false;
+	release?.();
+	release = undefined;
+}

--- a/src/services/Supabase.service.ts
+++ b/src/services/Supabase.service.ts
@@ -1,5 +1,5 @@
 import type { Session, User as SupabaseUser } from "@supabase/supabase-js";
-import { createClient } from "@supabase/supabase-js";
+import { supabase, SUPABASE_URL } from "./SupabaseClient";
 import type { User } from "../types/User";
 import { LEGACY_SUBSCRIPTION_PRICE_IDS } from "../types/Price";
 import type { ImageGenerationPermitted } from "../types/ImageGenerationTypes";
@@ -18,12 +18,9 @@ export type { SubscriptionTier, UserSubscription, ImageGenerationRecord, Marketp
 let userCache: SupabaseUser | null = null;
 let hydratedSessionUserId: string | null = null;
 
-export const SUPABASE_URL = "https://hglcltvwunzynnzduauy.supabase.co";
+export { supabase, SUPABASE_URL };
 export const PRO_REQUEST_FUNCTION_NAME = "handle-pro-request-x";
 export const PRO_REQUEST_ENDPOINT = `${SUPABASE_URL}/functions/v1/${PRO_REQUEST_FUNCTION_NAME}`;
-const SUPABASE_ANON_KEY =
-	"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhnbGNsdHZ3dW56eW5uemR1YXV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MTIzOTIsImV4cCI6MjA2OTI4ODM5Mn0.q4VZu-0vEZVdjSXAhlSogB9ihfPVwero0S4UFVCvMDQ";
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 const subscriptionBadgeClasses = [
 	"badge-tier-free",
@@ -101,7 +98,7 @@ supabase.auth.onAuthStateChange((event, session) => {
 	}
 
 	//on login
-	if (event === "SIGNED_IN" && session) {
+	if ((event === "SIGNED_IN" || event === "INITIAL_SESSION") && session) {
 		console.log("User signed in.");
 		void hydrateAuthenticatedSession(session);
 	} else if (event === "SIGNED_OUT") {

--- a/src/services/SupabaseClient.ts
+++ b/src/services/SupabaseClient.ts
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+
+// Shared by the migration preflight and the app, without starting UI/auth hydration.
+export const SUPABASE_URL = "https://hglcltvwunzynnzduauy.supabase.co";
+const SUPABASE_ANON_KEY =
+	"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhnbGNsdHZ3dW56eW5uemR1YXV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MTIzOTIsImV4cCI6MjA2OTI4ODM5Mn0.q4VZu-0vEZVdjSXAhlSogB9ihfPVwero0S4UFVCvMDQ";
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/src/services/Surface.service.ts
+++ b/src/services/Surface.service.ts
@@ -6,6 +6,7 @@ const surfacePlane = surfacePlaneElement;
 
 const closeTimers = new WeakMap<HTMLElement, number>();
 const focusRestoreTargets = new WeakMap<HTMLElement, HTMLElement>();
+const inertBackground = new Set<HTMLElement>();
 let activeSurface: HTMLElement | null = null;
 let outsideDismissPointerStart: { surface: HTMLElement; startedOutside: boolean } | null = null;
 const surfaceActiveClass = "surface-plane--active";
@@ -24,7 +25,7 @@ const FOCUSABLE_SELECTOR = [
 function isAvailableFocusTarget(candidate: HTMLElement): boolean {
 	if (candidate.hasAttribute("disabled")) return false;
 	if (candidate.closest(".hidden")) return false;
-	return true;
+	return candidate.getClientRects().length > 0;
 }
 
 function getSurface(elementId: string): HTMLElement | null {
@@ -49,15 +50,32 @@ function refreshSurfacePlaneState(): void {
 
 	surfacePlane.classList.toggle(surfaceActiveClass, openSurfaces.length > 0);
 	surfacePlane.classList.toggle(surfaceBlurredClass, hasOpenAdaptiveSheet);
+	const trapFocus = openSurfaces.some((element) => element.dataset.trapFocus === "true");
+	if (trapFocus) {
+		for (const child of document.body.children) {
+			if (
+				!(child instanceof HTMLElement) ||
+				child === surfacePlane ||
+				child.inert ||
+				child.matches("script, style")
+			)
+				continue;
+			child.inert = true;
+			inertBackground.add(child);
+		}
+	} else {
+		for (const child of inertBackground) child.inert = false;
+		inertBackground.clear();
+	}
 }
 
 function finishClose(element: HTMLElement): void {
 	element.classList.add("hidden");
 	element.classList.remove("surface-open", "surface-closing");
-	element.dispatchEvent(new CustomEvent("surface-closed"));
-	restoreFocus(element);
 	if (activeSurface === element) activeSurface = null;
 	refreshSurfacePlaneState();
+	restoreFocus(element);
+	element.dispatchEvent(new CustomEvent("surface-closed"));
 }
 
 function getInitialFocusTarget(element: HTMLElement): HTMLElement {
@@ -144,7 +162,34 @@ export function closeAll(): void {
 }
 
 document.addEventListener("keydown", (event) => {
-	if (event.key === "Escape" && activeSurface) close();
+	if (!activeSurface) return;
+	if (event.key === "Escape") {
+		event.preventDefault();
+		if (activeSurface.dataset.dismissOnEscape !== "false" && activeSurface.dataset.surfaceBusy !== "true") close();
+	}
+	if (event.key === "Tab" && activeSurface.dataset.trapFocus === "true") {
+		const targets = Array.from(activeSurface.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+			(target) => target.tabIndex >= 0 && isAvailableFocusTarget(target)
+		);
+		const first = targets[0];
+		const last = targets.at(-1);
+		if (!first || !last) {
+			event.preventDefault();
+			activeSurface.focus();
+		} else if (
+			event.shiftKey &&
+			(document.activeElement === first || !targets.includes(document.activeElement as HTMLElement))
+		) {
+			event.preventDefault();
+			last.focus();
+		} else if (
+			!event.shiftKey &&
+			(document.activeElement === last || !targets.includes(document.activeElement as HTMLElement))
+		) {
+			event.preventDefault();
+			first.focus();
+		}
+	}
 });
 
 surfacePlane.addEventListener("pointerdown", (event) => {

--- a/src/services/Sync.service.ts
+++ b/src/services/Sync.service.ts
@@ -202,7 +202,7 @@ function enqueue(op: Omit<QueuedOperation, "id" | "timestamp">): void {
  * Fetch the user's sync preferences from Supabase.
  * Returns null if no row exists (user never set up sync).
  */
-export async function fetchSyncPreferences(): Promise<SyncPreferences | null> {
+export async function fetchSyncPreferences(options: { throwOnError?: boolean } = {}): Promise<SyncPreferences | null> {
 	const user = await getCurrentUser();
 	if (!user) return null;
 
@@ -212,6 +212,9 @@ export async function fetchSyncPreferences(): Promise<SyncPreferences | null> {
 		.eq("user_id", user.id)
 		.maybeSingle();
 
+	if (error && options.throwOnError) {
+		throw new Error("Unable to check whether Cloud Sync is enabled. Reconnect and try importing again.");
+	}
 	if (error || !data) {
 		syncPrefsCache = null;
 		return null;

--- a/src/services/Takeout.service.ts
+++ b/src/services/Takeout.service.ts
@@ -139,12 +139,13 @@ function report(onProgress: ((progress: TakeoutProgress) => void) | undefined, p
 export async function buildTakeoutExport(
 	categories: readonly TakeoutCategory[],
 	onProgress?: (progress: TakeoutProgress) => void,
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	sourceOverride?: TakeoutSource
 ): Promise<BuildTakeoutExportResult> {
 	signal?.throwIfAborted();
 	if (categories.length === 0) throw new Error("Select at least one category to export.");
 
-	const source: TakeoutSource = syncService.isOnlineSyncEnabled() ? "cloud" : "local";
+	const source: TakeoutSource = sourceOverride ?? (syncService.isOnlineSyncEnabled() ? "cloud" : "local");
 	if (source === "cloud") assertCloudExportReady();
 
 	report(onProgress, { phase: "reading", completed: 0, total: 1, message: `Reading ${source} data…` });
@@ -492,9 +493,12 @@ export function downloadTakeout(takeout: TakeoutDocument, filename: string): voi
 	anchor.download = filename;
 	anchor.style.display = "none";
 	document.body.append(anchor);
-	anchor.click();
-	anchor.remove();
-	window.setTimeout(() => URL.revokeObjectURL(url), 0);
+	try {
+		anchor.click();
+	} finally {
+		anchor.remove();
+		window.setTimeout(() => URL.revokeObjectURL(url), 0);
+	}
 }
 
 function documentElement<K extends keyof HTMLElementTagNameMap>(tagName: K): HTMLElementTagNameMap[K] {

--- a/src/services/Takeout.service.ts
+++ b/src/services/Takeout.service.ts
@@ -201,8 +201,12 @@ export async function buildTakeoutExport(
 }
 
 export async function getTakeoutImportDestinations(): Promise<TakeoutImportDestinations> {
-	const syncEnabled = syncService.isOnlineSyncEnabled();
 	const user = await supabaseService.getCurrentUser();
+	// Migration defers sync startup UI, so its preference cache may not be populated yet.
+	if (user) {
+		await syncService.fetchSyncPreferences({ throwOnError: true });
+	}
+	const syncEnabled = syncService.isOnlineSyncEnabled();
 	const subscription = user ? await supabaseService.getUserSubscription() : null;
 	const tier = supabaseService.getSubscriptionTier(subscription);
 	const cloudEligible = !!user && (tier === "pro" || tier === "pro_plus" || tier === "max");

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2649,6 +2649,89 @@ form {
 		transform 0.18s ease;
 }
 
+.domain-migration-sheet {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: min(100%, 36rem);
+	max-height: calc(100dvh - 2rem);
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	padding: 1.75rem;
+	border-radius: 1.25rem;
+	background: var(--sidebar-bg, var(--body-bg, #20242d));
+	color: var(--body-fg, #f3f4f6);
+	border: var(--elevated-ui-outline, 1px solid rgb(255 255 255 / 15%));
+	box-shadow: 0 1rem 4rem rgb(0 0 0 / 25%);
+}
+
+.domain-migration-sheet h1 {
+	font-size: 1.8rem;
+	line-height: 1.2;
+}
+.domain-migration-sheet h1:focus {
+	outline: none;
+}
+.domain-migration-sheet h1,
+.domain-migration-sheet p {
+	margin: 0;
+}
+.domain-migration-destination {
+	overflow-wrap: anywhere;
+}
+.domain-migration-error {
+	font-size: 0.85rem;
+	color: var(--warning-fg, currentColor);
+}
+.domain-migration-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+}
+.domain-migration-actions > button {
+	width: 100%;
+}
+.domain-migration-acknowledgement {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.75rem;
+}
+.domain-migration-acknowledgement input[type="checkbox"] {
+	appearance: auto;
+	-webkit-appearance: auto;
+	accent-color: var(--primary);
+	margin-top: 0.3rem;
+	flex-shrink: 0;
+	width: 1.1rem;
+	height: 1.1rem;
+}
+.domain-migration-acknowledgement input[type="checkbox"]::before {
+	content: none;
+}
+.domain-migration-sheet :focus-visible {
+	outline: 2px solid currentColor;
+	outline-offset: 4px;
+}
+.surface-plane:has(.domain-migration-sheet:not(.hidden)) {
+	background: rgb(0 0 0 / 35%);
+	backdrop-filter: blur(10px);
+}
+
+@media (max-width: 640px) {
+	.domain-migration-sheet {
+		padding: 1.25rem;
+	}
+	.domain-migration-actions > button {
+		width: 100%;
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.surface-plane,
+	.surface-plane .surface-plane__item {
+		transition: none;
+	}
+}
+
 .surface-plane__item.surface-open {
 	opacity: 1;
 	transform: translateY(0) scale(1);
@@ -2755,6 +2838,26 @@ form {
 .takeout-file-picker:hover,
 .takeout-file-picker:has(+ input:focus-visible) {
 	border-color: color-mix(in srgb, var(--primary) 55%, currentColor 15%);
+}
+
+/* Keep custom takeout checkboxes keyboard/screen-reader accessible. The
+   onboarding checkbox styling otherwise hides the native input entirely. */
+.takeout-sheet .onboarding-checkbox-label {
+	position: relative;
+}
+.takeout-sheet .onboarding-checkbox-label input[type="checkbox"],
+.takeout-sheet .onboarding-checkbox-label input[type="checkbox"]:disabled {
+	display: block;
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	opacity: 0;
+}
+
+#main-container[aria-busy="true"] {
+	pointer-events: none;
 }
 
 .takeout-option:has(input:disabled) {

--- a/tests/e2e/announcements/dev-announcement-preview.spec.ts
+++ b/tests/e2e/announcements/dev-announcement-preview.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
+
+test("debug composer saves a one-time announcement for the next refresh", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await page.route("https://example.test/announcement.svg", async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "image/svg+xml",
+			body: '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="360"><rect width="800" height="360" fill="#614a3a"/></svg>'
+		});
+	});
+	await seedLocalSettings(page);
+	await page.goto("/?migration=empty");
+
+	await page.locator(".navbar-tab").nth(2).click();
+	await page.locator("#btn-debug-announcement").click();
+
+	const form = page.locator("#form-debug-announcement");
+	await expect(form).toBeVisible();
+	await form.locator("#debug-announcement-title").fill("A preview announcement");
+	await form.locator("#debug-announcement-body").fill("This message should appear after refresh.");
+	await form.locator("#debug-announcement-hero-url").fill("https://example.test/announcement.svg");
+	await form.locator("#debug-announcement-hero-alt").fill("A brown preview image");
+	await form.locator("#debug-announcement-action").selectOption("next");
+	await form.locator("#debug-announcement-action-label").fill("Continue");
+	await form.getByRole("button", { name: "Save for next refresh" }).click();
+
+	await expect(form).toBeHidden();
+	await expect
+		.poll(() =>
+			page.evaluate(() => {
+				const stored = localStorage.getItem("debug-announcement-preview");
+				return stored ? JSON.parse(stored) : null;
+			})
+		)
+		.toEqual(
+			expect.objectContaining({
+				title: "A preview announcement",
+				body: "This message should appear after refresh.",
+				heroImageUrl: "https://example.test/announcement.svg",
+				heroImageAlt: "A brown preview image",
+				action: "next",
+				actionLabel: "Continue"
+			})
+		);
+
+	await page.reload();
+
+	const announcement = page.getByRole("dialog", { name: "A preview announcement" });
+	await expect(announcement).toBeVisible();
+	await expect(announcement).toContainText("This message should appear after refresh.");
+	await expect(announcement.locator("#targeted-announcement-image")).toHaveAttribute("alt", "A brown preview image");
+	await expect(announcement.getByRole("button", { name: "Continue" })).toBeVisible();
+	await expect.poll(() => page.evaluate(() => localStorage.getItem("debug-announcement-preview"))).not.toBeNull();
+
+	await page.reload();
+	await expect(page.getByRole("dialog", { name: "A preview announcement" })).toBeVisible();
+
+	await page.getByRole("button", { name: "Continue" }).click();
+	await expect(page.locator("#targeted-announcement")).toBeHidden();
+	await expect.poll(() => page.evaluate(() => localStorage.getItem("debug-announcement-preview"))).toBeNull();
+});

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -2,67 +2,6 @@ import { expect, test } from "@playwright/test";
 
 import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
 
-test("debug composer saves a one-time announcement for the next refresh", async ({ page }) => {
-	await stubExternalTraffic(page, []);
-	await page.route("https://example.test/announcement.svg", async (route) => {
-		await route.fulfill({
-			status: 200,
-			contentType: "image/svg+xml",
-			body: '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="360"><rect width="800" height="360" fill="#614a3a"/></svg>'
-		});
-	});
-	await seedLocalSettings(page);
-	await page.goto("/");
-
-	await page.locator(".navbar-tab").nth(2).click();
-	await page.locator("#btn-debug-announcement").click();
-
-	const form = page.locator("#form-debug-announcement");
-	await expect(form).toBeVisible();
-	await form.locator("#debug-announcement-title").fill("A preview announcement");
-	await form.locator("#debug-announcement-body").fill("This message should appear after refresh.");
-	await form.locator("#debug-announcement-hero-url").fill("https://example.test/announcement.svg");
-	await form.locator("#debug-announcement-hero-alt").fill("A brown preview image");
-	await form.locator("#debug-announcement-action").selectOption("next");
-	await form.locator("#debug-announcement-action-label").fill("Continue");
-	await form.getByRole("button", { name: "Save for next refresh" }).click();
-
-	await expect(form).toBeHidden();
-	await expect
-		.poll(() =>
-			page.evaluate(() => {
-				const stored = localStorage.getItem("debug-announcement-preview");
-				return stored ? JSON.parse(stored) : null;
-			})
-		)
-		.toEqual(
-			expect.objectContaining({
-				title: "A preview announcement",
-				body: "This message should appear after refresh.",
-				heroImageUrl: "https://example.test/announcement.svg",
-				heroImageAlt: "A brown preview image",
-				action: "next",
-				actionLabel: "Continue"
-			})
-		);
-
-	await page.reload();
-
-	const announcement = page.getByRole("dialog", { name: "A preview announcement" });
-	await expect(announcement).toBeVisible();
-	await expect(announcement).toContainText("This message should appear after refresh.");
-	await expect(announcement.locator("#targeted-announcement-image")).toHaveAttribute("alt", "A brown preview image");
-	await expect(announcement.getByRole("button", { name: "Continue" })).toBeVisible();
-	await expect.poll(() => page.evaluate(() => localStorage.getItem("debug-announcement-preview"))).not.toBeNull();
-
-	await page.reload();
-	await expect(page.getByRole("dialog", { name: "A preview announcement" })).toBeVisible();
-
-	await page.getByRole("button", { name: "Continue" }).click();
-	await expect(page.locator("#targeted-announcement")).toBeHidden();
-	await expect.poll(() => page.evaluate(() => localStorage.getItem("debug-announcement-preview"))).toBeNull();
-});
-
 test("eligible announcements render optional hero media and advance through app actions", async ({ page }) => {
 	const receiptWrites: Array<Record<string, string>> = [];
 
@@ -134,6 +73,7 @@ test("eligible announcements render optional hero media and advance through app 
 	await seedLocalSettings(page);
 	await page.goto("/");
 
+	await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
 	await page.evaluate(() => {
 		window.dispatchEvent(
 			new CustomEvent("auth-state-changed", {

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -1,6 +1,60 @@
 import { expect, test } from "@playwright/test";
 
 import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
+import { newOrigin, seed, serveApp } from "../helpers/migration";
+
+test("a deferred announcement appears when an ordinary import sheet closes", async ({ page }) => {
+	await serveApp(page, { syncEnabled: false });
+	let releaseAnnouncement!: () => void;
+	const announcementReady = new Promise<void>((resolve) => {
+		releaseAnnouncement = resolve;
+	});
+	await page.route("**/rest/v1/announcements*", async (route) => {
+		await announcementReady;
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify([
+				{
+					id: "surface-deferred-announcement",
+					key: "surface-deferred-announcement",
+					title: "Ready after import",
+					body: "This announcement waits for the import sheet to close.",
+					hero_image_url: null,
+					hero_image_alt: null,
+					action: "dismiss",
+					action_label: "Got it"
+				}
+			])
+		});
+	});
+	await seed(page, { origin: newOrigin, signedIn: true, settings: { onboardingCompleted: "true" } });
+	await page.goto(newOrigin);
+	await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
+	await page.locator(".navbar-tab").filter({ hasText: "Settings" }).first().click();
+	await page.locator('[data-settings-target="data"]').click();
+	await page.locator("#btn-import-data").click();
+	await expect(page.locator("#takeout-import-sheet")).toBeVisible();
+	const receiptsLoaded = page.waitForResponse((response) =>
+		new URL(response.url()).pathname.endsWith("/announcement_receipts")
+	);
+	releaseAnnouncement();
+	await (await receiptsLoaded).finished();
+	// Allow the real fetch continuation and presentation attempt to finish while the sheet is open.
+	await page.evaluate(
+		() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+	);
+	const announcement = page.getByRole("dialog", { name: "Ready after import" });
+	await expect(announcement).toBeHidden();
+	await page.locator("#btn-takeout-import-close").click();
+	await expect(
+		announcement,
+		"Closing the sheet must resume the pending announcement without a refresh"
+	).toBeVisible();
+	await expect(page.locator("#takeout-import-sheet")).toBeHidden();
+	await announcement.getByRole("button", { name: "Got it" }).click();
+	await expect(announcement).toBeHidden();
+});
 
 test("eligible announcements render optional hero media and advance through app actions", async ({ page }) => {
 	const receiptWrites: Array<Record<string, string>> = [];

--- a/tests/e2e/helpers/migration.ts
+++ b/tests/e2e/helpers/migration.ts
@@ -1,0 +1,144 @@
+import type { Page } from "@playwright/test";
+
+export const oldOrigin = "https://zodiac.faetalize.dev";
+export const newOrigin = "https://chat.zozo.sh";
+const localServer = "https://127.0.0.1:4173";
+const user = {
+	id: "11111111-1111-4111-8111-111111111111",
+	email: "migration@example.test",
+	aud: "authenticated",
+	role: "authenticated",
+	app_metadata: {},
+	user_metadata: {},
+	created_at: "2026-01-01T00:00:00Z"
+};
+
+export async function observeMigrationBeforeRedirect(page: Page): Promise<string[]> {
+	const shown: string[] = [];
+	await page.exposeFunction("recordMigrationPresentation", (id: string) => shown.push(id));
+	await page.addInitScript(() => {
+		if (window.location.hostname !== "zodiac.faetalize.dev") return;
+		new MutationObserver(() => {
+			const sheet = document.getElementById("domain-migration-sheet");
+			if (sheet && !sheet.classList.contains("hidden")) {
+				void (window as any).recordMigrationPresentation(sheet.id);
+			}
+		}).observe(document, { childList: true, subtree: true, attributes: true, attributeFilter: ["class"] });
+	});
+	return shown;
+}
+
+// Type 3: serve the real app on distinct browser origins. Only network sources
+// are stubbed; the entrypoint, components, storage, download, and navigation run.
+export async function serveApp(
+	page: Page,
+	options: { syncEnabled?: boolean; failPreference?: boolean; server?: string } = {}
+) {
+	const requests: string[] = [];
+	await page.route("https://**/*", async (route) => {
+		const url = new URL(route.request().url());
+		if (url.hostname.endsWith(".supabase.co")) {
+			requests.push(url.pathname);
+			let body: unknown = [];
+			let status = 200;
+			if (url.pathname === "/auth/v1/user") body = user;
+			if (url.pathname.endsWith("/user_sync_preferences")) {
+				body =
+					options.syncEnabled === undefined
+						? null
+						: {
+								sync_enabled: options.syncEnabled,
+								encryption_salt: "ab".repeat(16),
+								key_verification: "cd".repeat(16),
+								key_verification_iv: "ef".repeat(12)
+							};
+				if (options.failPreference) {
+					status = 503;
+					body = { message: "Test connection failure" };
+				}
+			}
+			if (url.pathname.endsWith("/profiles"))
+				body = { id: user.id, preferred_name: "", avatar: "", system_prompt_addition: "" };
+			await route.fulfill({
+				status,
+				contentType: "application/json",
+				body: JSON.stringify(body),
+				headers: { "access-control-allow-origin": "*" }
+			});
+			return;
+		}
+		if (
+			[
+				"zodiac.faetalize.dev",
+				"chat.zozo.sh",
+				"preview.zodiac.faetalize.dev",
+				"zodiac.faetalize.dev.example.test",
+				"preview.example.test",
+				"localhost",
+				"127.0.0.1"
+			].includes(url.hostname)
+		) {
+			if (url.pathname === "/seed") {
+				await route.fulfill({
+					contentType: "text/html",
+					body: "<!doctype html><html><body>Seed browser data</body></html>"
+				});
+				return;
+			}
+			const response = await route.fetch({ url: (options.server ?? localServer) + url.pathname + url.search });
+			await route.fulfill({ response });
+			return;
+		}
+		await route.fulfill({
+			status: 200,
+			contentType: route.request().resourceType() === "stylesheet" ? "text/css" : "application/javascript",
+			body: ""
+		});
+	});
+	return requests;
+}
+
+export async function seed(
+	page: Page,
+	options: { origin?: string; chat?: boolean; settings?: Record<string, string>; signedIn?: boolean } = {}
+) {
+	await page.goto(`${options.origin ?? oldOrigin}/seed`);
+	await page.evaluate(
+		async ({ chat, settings, signedIn, account }) => {
+			for (const [key, value] of Object.entries(settings ?? {})) localStorage.setItem(key, value);
+			if (signedIn)
+				localStorage.setItem(
+					"sb-hglcltvwunzynnzduauy-auth-token",
+					JSON.stringify({
+						access_token: "test-access-token",
+						refresh_token: "test-refresh-token",
+						token_type: "bearer",
+						expires_in: 3600,
+						expires_at: Math.floor(Date.now() / 1000) + 3600,
+						user: account
+					})
+				);
+			if (chat) {
+				const importModule = new Function("path", "return import(path)");
+				const { db } = await importModule("/services/Db.service.ts");
+				await db.chats.put({
+					id: "migration-chat",
+					title: "My local story",
+					timestamp: 1000,
+					content: [
+						{
+							role: "user",
+							parts: [
+								{
+									text: "Keep this story",
+									attachments: [new File(["attachment content"], "story.txt", { type: "text/plain" })]
+								}
+							]
+						}
+					]
+				});
+			}
+		},
+		{ ...options, account: user }
+	);
+}

--- a/tests/e2e/migration/dev-domain-migration.spec.ts
+++ b/tests/e2e/migration/dev-domain-migration.spec.ts
@@ -1,0 +1,84 @@
+import { readFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+import { serveApp, seed } from "../helpers/migration";
+
+const devServer = "https://127.0.0.1:4175";
+
+for (const origin of ["https://localhost:4175", devServer]) {
+	test(`dev migration returns to ${origin} and consumes Import once`, async ({ page }) => {
+		await serveApp(page, { server: devServer });
+		await seed(page, { origin, chat: true, settings: { onboardingCompleted: "true" } });
+		const navigations: string[] = [];
+		page.on("framenavigated", (frame) => {
+			if (frame === page.mainFrame()) navigations.push(frame.url());
+		});
+		await page.goto(origin);
+		await expect(page.locator("#domain-migration-sheet")).toBeVisible();
+		await page.locator("#btn-migration-export").click();
+		const downloading = page.waitForEvent("download");
+		await page.locator("#btn-takeout-export").click();
+		const download = await downloading;
+		const bytes = await readFile((await download.path())!);
+		await page.locator("#btn-takeout-export-close").click();
+		await page.locator("#migration-confirmed").check();
+		await page.locator("#btn-migration-continue").click();
+		await expect(page.locator("#takeout-import-sheet")).toBeVisible();
+		await expect(page).toHaveURL(`${origin}/`);
+		expect(navigations).toContain(`${origin}/?migration=takeout-v1`);
+		expect(navigations.every((url) => new URL(url).origin === origin)).toBe(true);
+		await page
+			.locator("#takeout-import-files")
+			.setInputFiles({ name: "dev-takeout.json", mimeType: "application/json", buffer: bytes });
+		await page.locator("#btn-takeout-import").click();
+		await expect(page.locator("#takeout-import-status")).toContainText("Skipped 1 record already present");
+		await page.reload();
+		await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
+		await expect(page.locator("#domain-migration-sheet")).toBeHidden();
+		await expect(page.locator("#takeout-import-sheet")).toBeHidden();
+		await expect(page).toHaveURL(`${origin}/`);
+		await page.locator(".navbar-tab").filter({ hasText: "Settings" }).first().click();
+		await page.locator("#debug-section").getByRole("button", { name: "Test migration", exact: true }).click();
+		await expect(page.locator("#domain-migration-sheet")).toBeVisible();
+		await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+		await page.locator("#migration-confirmed").check();
+		await page.locator("#btn-migration-continue").click();
+		await expect.poll(() => navigations).toContain(`${origin}/?migration=continue`);
+		await expect(page).toHaveURL(`${origin}/`);
+		await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
+		await expect(page.locator("#takeout-import-sheet")).toBeHidden();
+	});
+}
+
+test("an empty dev browser returns once to the same origin without a redirect loop", async ({ page }) => {
+	await serveApp(page, { server: devServer });
+	const arrivals: string[] = [];
+	page.on("framenavigated", (frame) => {
+		if (frame === page.mainFrame()) arrivals.push(frame.url());
+	});
+	await page.goto(devServer);
+	await expect.poll(() => arrivals).toContain(`${devServer}/?migration=empty`);
+	await expect(page).toHaveURL(`${devServer}/`);
+	await expect(page.locator("#migration-arrival-notice")).toHaveCount(0);
+	await page.reload();
+	await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
+	await expect(page.locator("#domain-migration-sheet")).toBeHidden();
+	expect(arrivals.filter((url) => new URL(url).searchParams.get("migration") === "empty")).toHaveLength(1);
+	expect(arrivals.every((url) => new URL(url).origin === devServer)).toBe(true);
+});
+
+test("enabled Cloud Sync in dev returns to the same origin and retains its session", async ({ page }) => {
+	await serveApp(page, { server: devServer, syncEnabled: true });
+	await seed(page, { origin: devServer, signedIn: true, settings: { onboardingCompleted: "true" } });
+	const arrivals: string[] = [];
+	page.on("framenavigated", (frame) => {
+		if (frame === page.mainFrame()) arrivals.push(frame.url());
+	});
+	await page.goto(devServer);
+	await expect.poll(() => arrivals).toContain(`${devServer}/?migration=cloud`);
+	await expect(page).toHaveURL(`${devServer}/`);
+	await expect(page.locator("#migration-arrival-notice")).toHaveCount(0);
+	await expect(page.locator("#domain-migration-sheet")).toBeHidden();
+	expect(arrivals).toContain(`${devServer}/?migration=cloud`);
+	expect(arrivals.every((url) => new URL(url).origin === devServer)).toBe(true);
+	expect(await page.evaluate(() => localStorage.getItem("sb-hglcltvwunzynnzduauy-auth-token"))).not.toBeNull();
+});

--- a/tests/e2e/migration/domain-migration.spec.ts
+++ b/tests/e2e/migration/domain-migration.spec.ts
@@ -1,0 +1,313 @@
+import { readFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+import { oldOrigin, newOrigin, observeMigrationBeforeRedirect, serveApp, seed } from "../helpers/migration";
+
+test("confirmation can continue with an export to Import or without an export to the normal app", async ({ page }) => {
+	await serveApp(page);
+	await seed(page, { chat: true, settings: { API_KEY: "test-gemini-key", pinnedChatIds: '["migration-chat"]' } });
+	await page.goto(oldOrigin);
+	const gate = page.getByRole("dialog", { name: "Zodiac is now Zozo" });
+	await expect(gate).toBeVisible();
+	await expect(page.locator("#onboarding-overlay")).toBeHidden();
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	await expect(page.locator("#migration-confirmed")).toBeEnabled();
+	await page.keyboard.press("Escape");
+	await expect(gate).toBeVisible();
+	await page.locator("#btn-migration-export").click();
+	await expect(page.locator("#takeout-category-apiKeys")).not.toBeChecked();
+	await expect(page.locator("#takeout-category-media")).toBeChecked();
+	const downloading = page.waitForEvent("download");
+	await page.locator("#btn-takeout-export").click();
+	const download = await downloading;
+	const bytes = await readFile((await download.path())!);
+	const takeout = JSON.parse(bytes.toString());
+	expect(takeout.source).toBe("local");
+	expect(takeout.payload.chats[0].content[0].parts[0].attachments[0].base64).toBe(
+		Buffer.from("attachment content").toString("base64")
+	);
+	expect(takeout.payload.settings.API_KEY).toBeUndefined();
+	await page.locator("#btn-takeout-export-close").click();
+	await expect(gate).toBeVisible();
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	await page.locator("#migration-confirmed").check();
+	await expect(page.locator("#btn-migration-continue")).toBeEnabled();
+	await page.locator("#btn-migration-continue").click();
+	await expect(page).toHaveURL(`${newOrigin}/`);
+	await expect(page.locator("#takeout-import-sheet")).toBeVisible();
+	await expect(page.locator("#onboarding-overlay")).toBeHidden();
+	await page
+		.locator("#takeout-import-files")
+		.setInputFiles({ name: "takeout.json", mimeType: "application/json", buffer: bytes });
+	await page.locator("#btn-takeout-import").click();
+	await expect(page.locator("#takeout-import-status")).toContainText("Imported 1 chat");
+	await page.reload();
+	await expect(page.locator("#takeout-import-sheet")).toBeHidden();
+	// The old origin still holds the original, and a new visit rechecks it.
+	await page.goto(oldOrigin);
+	await expect(gate).toBeVisible();
+	await expect(page.locator("#domain-migration-status")).toBeHidden();
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	expect(await page.evaluate(() => localStorage.getItem("API_KEY"))).toBe("test-gemini-key");
+	await page.locator("#migration-confirmed").check();
+	await expect(page.locator("#btn-migration-continue")).toBeEnabled();
+	await page.locator("#migration-confirmed").uncheck();
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	await page.locator("#migration-confirmed").check();
+	await page.locator("#btn-migration-continue").click();
+	await expect(page).toHaveURL(`${newOrigin}/`);
+	await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
+	await expect(page.locator("#takeout-import-sheet")).toBeHidden();
+});
+
+test("enabled but locked Cloud Sync redirects without fetching data or showing unlock", async ({ page }) => {
+	const requests = await serveApp(page, { syncEnabled: true });
+	const migrationPresentations = await observeMigrationBeforeRedirect(page);
+	await seed(page, { signedIn: true, chat: true });
+	await page.goto(oldOrigin);
+	await expect(page).toHaveURL(`${newOrigin}/`);
+	await expect(page.locator("#migration-arrival-notice")).toHaveCount(0);
+	await expect(page.locator("#takeout-import-sheet")).toBeHidden();
+	await expect(page.locator("#sync-modal")).toBeHidden();
+	expect(migrationPresentations, "The old-domain migration sheet must never flash before a cloud redirect").toEqual(
+		[]
+	);
+	expect(requests.filter((path) => path.includes("user_synced_"))).toEqual([]);
+	expect(requests.filter((path) => path.endsWith("user_sync_preferences"))).toHaveLength(1);
+	expect(await page.evaluate(() => localStorage.getItem("sb-hglcltvwunzynnzduauy-auth-token"))).toBeNull();
+});
+
+test("disabled sync still protects local data even when old encrypted cloud data exists", async ({ page }) => {
+	await serveApp(page, { syncEnabled: false });
+	await seed(page, { signedIn: true, chat: true, settings: { onboardingCompleted: "true" } });
+	await page.goto(oldOrigin);
+	await expect(page.locator("#btn-migration-export")).toBeEnabled();
+	await expect(page.locator("#sync-modal")).toBeHidden();
+	await expect(page).toHaveURL(`${oldOrigin}/`);
+	await page.locator("#btn-migration-export").click();
+	await expect(page.locator("#takeout-export-source")).toContainText("this browser");
+});
+
+test("a failed preference check offers retry and cannot redirect as empty", async ({ page }) => {
+	const source = { syncEnabled: false, failPreference: true };
+	await serveApp(page, source);
+	await seed(page, { signedIn: true, chat: true });
+	await page.goto(oldOrigin);
+	await expect(page.locator("#domain-migration-status")).toContainText(
+		/Unable to check whether Cloud Sync|data check took too long/,
+		{ timeout: 20_000 }
+	);
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	await expect(page.locator("#btn-migration-export")).toBeDisabled();
+	source.failPreference = false;
+	await page.locator("#btn-migration-retry").click();
+	await expect(page.locator("#btn-migration-export")).toBeEnabled();
+});
+
+test("the transition cannot be dismissed into the old app, including with a legacy Stay flag", async ({ page }) => {
+	await serveApp(page);
+	await seed(page, { chat: true, settings: { onboardingCompleted: "true" } });
+	await page.evaluate(() => sessionStorage.setItem("zozo-migration-dismissed", "true"));
+	await page.goto(oldOrigin);
+	await expect(page.locator("#btn-migration-export")).toBeEnabled();
+	await expect(page.locator("#btn-migration-stay")).toHaveCount(0);
+	await page.keyboard.press("Escape");
+	await page.locator("#surface-plane").click({ position: { x: 4, y: 4 } });
+	await expect(page.locator("#domain-migration-sheet")).toBeVisible();
+	await page.locator("#btn-migration-export").click();
+	await page.locator("#btn-takeout-export-close").click();
+	await expect(page.locator("#domain-migration-sheet")).toBeVisible();
+	await expect(page.locator("#main-container")).toHaveAttribute("inert", "");
+	await expect(page.locator("#debug-section")).toBeHidden();
+	await expect(page.locator("#btn-debug-migration")).toBeHidden();
+	await expect(page.locator("#btn-resume-migration")).toHaveCount(0);
+	await page.reload();
+	await expect(page.locator("#domain-migration-sheet")).toBeVisible();
+});
+
+test("a fresh browser and runtime-only storage redirect without a takeout", async ({ page }) => {
+	await serveApp(page);
+	const migrationPresentations = await observeMigrationBeforeRedirect(page);
+	await seed(page, {
+		settings: {
+			onboardingCompleted: "true",
+			syncPromptSeen: "true",
+			pinnedChatIds: "[]",
+			loras: "[]",
+			roleplayCustomActions: "[]",
+			"debug-announcement-preview": "{}"
+		}
+	});
+	await page.goto(oldOrigin);
+	await expect(page).toHaveURL(`${newOrigin}/`);
+	await expect(page.locator("#migration-arrival-notice")).toHaveCount(0);
+	await expect(page.locator("#takeout-import-sheet")).toBeHidden();
+	expect(
+		migrationPresentations,
+		"The old-domain migration sheet must never flash before an empty-browser redirect"
+	).toEqual([]);
+});
+
+for (const hostname of [
+	"chat.zozo.sh",
+	"preview.zodiac.faetalize.dev",
+	"zodiac.faetalize.dev.example.test",
+	"preview.example.test",
+	"localhost",
+	"127.0.0.1"
+]) {
+	test(`the old-domain gate does not run on ${hostname}`, async ({ page }) => {
+		await serveApp(page);
+		const origin = `https://${hostname}`;
+		await seed(page, { origin, settings: { API_KEY: "local-test-key", onboardingCompleted: "true" } });
+		await page.goto(origin);
+		await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
+		await expect(page.locator("#domain-migration-sheet")).toBeHidden();
+		await expect(page.locator("#takeout-import-sheet")).toBeHidden();
+		await expect(page).toHaveURL(`${origin}/`);
+	});
+}
+
+test("narrow-screen keyboard flow keeps focus inside and Escape does not continue", async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await serveApp(page);
+	await seed(page, { settings: { "theme-settings": '{"colorTheme":"purple","mode":"dark","preference":"manual"}' } });
+	await page.goto(oldOrigin);
+	await expect(page.locator("#btn-migration-export")).toBeEnabled();
+	await page.screenshot({ path: "test-results/migration-mobile.png", fullPage: true });
+	await page.locator("#migration-confirmed").focus();
+	await page.keyboard.press("Tab");
+	await expect(page.locator("#domain-migration-description a")).toBeFocused();
+	await page.keyboard.press("Shift+Tab");
+	await expect(page.locator("#migration-confirmed")).toBeFocused();
+	await page.keyboard.press("Escape");
+	await expect(page.locator("#domain-migration-sheet")).toBeVisible();
+	const bounds = await page.locator("#domain-migration-sheet").boundingBox();
+	expect(bounds!.x).toBeGreaterThanOrEqual(0);
+	expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(390);
+});
+
+test("unreadable local storage stays recoverable and is never classified as empty", async ({ page }) => {
+	await serveApp(page);
+	await seed(page);
+	await page.addInitScript(() => {
+		const read = Storage.prototype.getItem;
+		Storage.prototype.getItem = function (key) {
+			if (key === "loras" && !sessionStorage.getItem("test-storage-recovered"))
+				throw new DOMException("Storage unavailable", "SecurityError");
+			return read.call(this, key);
+		};
+	});
+	await page.goto(oldOrigin);
+	await expect(page.locator("#domain-migration-status")).toContainText("Storage unavailable");
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	await page.evaluate(() => {
+		sessionStorage.setItem("test-storage-recovered", "true");
+		localStorage.setItem("OPENROUTER_API_KEY", "recovered-key");
+	});
+	await page.locator("#btn-migration-retry").click();
+	await expect(page.locator("#btn-migration-export")).toBeEnabled();
+	await expect(page.locator("#domain-migration-status")).toBeHidden();
+});
+
+test("export failure and cancellation do not reset confirmation or change source records", async ({ page }) => {
+	await serveApp(page);
+	await seed(page, { chat: true });
+	await page.addInitScript(() => {
+		const click = HTMLAnchorElement.prototype.click;
+		HTMLAnchorElement.prototype.click = function () {
+			if (this.download && !sessionStorage.getItem("test-allow-download"))
+				throw new Error("Download was blocked");
+			return click.call(this);
+		};
+	});
+	await page.goto(oldOrigin);
+	await expect(page.locator("#btn-migration-export")).toBeEnabled();
+	await page.screenshot({ path: "test-results/migration-desktop.png", fullPage: true });
+	await page.locator("#btn-migration-export").click();
+	await page.locator("#btn-takeout-export").click();
+	await expect(page.locator("#takeout-export-status")).toContainText("Download was blocked");
+	await page.locator("#btn-takeout-export-close").click();
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	await expect(page.locator("#migration-confirmed")).toBeEnabled();
+	await page.evaluate(() => sessionStorage.setItem("test-allow-download", "true"));
+	await page.locator("#btn-migration-export").click();
+	const downloading = page.waitForEvent("download");
+	await page.locator("#btn-takeout-export").click();
+	await downloading;
+	await page.locator("#btn-takeout-export-close").click();
+	await page.locator("#migration-confirmed").check();
+	await expect(page.locator("#btn-migration-continue")).toBeEnabled();
+	// Export actions do not revoke the user's independent confirmation.
+	await page.locator("#btn-migration-export").click();
+	await page.locator("#btn-takeout-export-close").click();
+	await expect(page.locator("#btn-migration-continue")).toBeEnabled();
+	const record = await page.evaluate(async () => {
+		const importModule = new Function("path", "return import(path)");
+		const { db } = await importModule("/services/Db.service.ts");
+		return await db.chats.get("migration-chat");
+	});
+	expect(record.content[0].parts[0].text).toBe("Keep this story");
+});
+
+test("an unresolved media item fails export but leaves confirmation available", async ({ page }) => {
+	await serveApp(page);
+	await seed(page, { chat: true });
+	await page.evaluate(async () => {
+		const importModule = new Function("path", "return import(path)");
+		const { db } = await importModule("/services/Db.service.ts");
+		const chat = await db.chats.get("migration-chat");
+		chat.content[0].generatedImages = [
+			{ base64: "", mimeType: "image/png", _blobRef: { blobId: "unavailable-media" } }
+		];
+		await db.chats.put(chat);
+	});
+	await page.goto(oldOrigin);
+	await page.locator("#btn-migration-export").click();
+	await page.locator("#btn-takeout-export").click();
+	await expect(page.locator("#takeout-export-status")).toContainText("unresolved cloud blob reference");
+	await page.locator("#btn-takeout-export-close").click();
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	await page.locator("#migration-confirmed").check();
+	await expect(page.locator("#btn-migration-continue")).toBeEnabled();
+	await page.locator("#migration-confirmed").uncheck();
+	await page.locator("#btn-migration-export").click();
+	await page.locator("#takeout-category-media").uncheck();
+	const downloading = page.waitForEvent("download");
+	await page.locator("#btn-takeout-export").click();
+	const download = await downloading;
+	const takeout = JSON.parse(await readFile((await download.path())!, "utf8"));
+	expect(takeout.manifest.omittedCategories).toContain("media");
+	await page.locator("#btn-takeout-export-close").click();
+	await expect(page.locator("#domain-migration-status")).toBeHidden();
+	await page.locator("#migration-confirmed").check();
+	await expect(page.locator("#btn-migration-continue")).toBeEnabled();
+});
+
+test("cancelling during attachment reading starts no download and confirmation still allows continuing", async ({
+	page
+}) => {
+	await serveApp(page);
+	await seed(page, { chat: true });
+	await page.addInitScript(() => {
+		const read = FileReader.prototype.readAsDataURL;
+		FileReader.prototype.readAsDataURL = function (file) {
+			const resume = () => read.call(this, file);
+			window.addEventListener("test-finish-attachment-read", resume, { once: true });
+		};
+	});
+	let downloads = 0;
+	page.on("download", () => downloads++);
+	await page.goto(oldOrigin);
+	await page.locator("#btn-migration-export").click();
+	await page.locator("#btn-takeout-export").click();
+	await expect(page.locator("#takeout-export-status")).toContainText("Building takeout");
+	await page.locator("#btn-takeout-export-cancel").click();
+	await page.evaluate(() => window.dispatchEvent(new Event("test-finish-attachment-read")));
+	await expect(page.locator("#takeout-export-status")).toContainText("Export canceled");
+	await page.locator("#btn-takeout-export-close").click();
+	await expect(page.locator("#btn-migration-continue")).toBeDisabled();
+	expect(downloads).toBe(0);
+	await page.locator("#migration-confirmed").check();
+	await expect(page.locator("#btn-migration-continue")).toBeEnabled();
+});

--- a/tests/e2e/migration/domain-migration.spec.ts
+++ b/tests/e2e/migration/domain-migration.spec.ts
@@ -76,6 +76,56 @@ test("enabled but locked Cloud Sync redirects without fetching data or showing u
 	expect(await page.evaluate(() => localStorage.getItem("sb-hglcltvwunzynnzduauy-auth-token"))).toBeNull();
 });
 
+test("migration import respects Cloud Sync already enabled on the destination account", async ({ page }) => {
+	await serveApp(page, { syncEnabled: true });
+	await page.route("**/rest/v1/user_subscriptions*", async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				user_id: "11111111-1111-4111-8111-111111111111",
+				status: "active",
+				price_id: "price_1SOU2lKcI9PDo3JBhsT8URS9",
+				current_period_end: "2026-12-31T00:00:00.000Z",
+				cancel_at_period_end: false
+			})
+		});
+	});
+	await seed(page, { origin: newOrigin, signedIn: true, settings: { onboardingCompleted: "true" } });
+	await seed(page, { chat: true });
+	await page.goto(oldOrigin);
+	await page.locator("#btn-migration-export").click();
+	const downloading = page.waitForEvent("download");
+	await page.locator("#btn-takeout-export").click();
+	const download = await downloading;
+	const bytes = await readFile((await download.path())!);
+	await page.locator("#btn-takeout-export-close").click();
+	await page.locator("#migration-confirmed").check();
+	await page.locator("#btn-migration-continue").click();
+	await expect(page.locator("#takeout-import-sheet")).toBeVisible();
+	await expect(
+		page.locator("#takeout-destination-local"),
+		"Migration must not offer local import for a synced account"
+	).toBeDisabled();
+	await expect(page.locator("#takeout-destination-cloud")).toBeChecked();
+	await expect(page.locator("#sync-modal")).toBeHidden();
+	await page
+		.locator("#takeout-import-files")
+		.setInputFiles({ name: "takeout.json", mimeType: "application/json", buffer: bytes });
+	await page.locator("#btn-takeout-import").click();
+	await expect(page.locator("#takeout-import-status")).toContainText("Set up or unlock Cloud Sync");
+	const destination = await page.evaluate(async () => {
+		const importModule = new Function("path", "return import(path)");
+		const { db } = await importModule("/services/Db.service.ts");
+		const sync = await importModule("/services/Sync.service.ts");
+		return { syncEnabled: sync.isOnlineSyncEnabled(), localChats: await db.chats.count() };
+	});
+	expect(destination).toEqual({ syncEnabled: true, localChats: 0 });
+	await page.locator("#btn-takeout-prepare-cloud").click();
+	await expect(page.locator("#sync-modal")).toBeVisible();
+	await expect(page.locator("#sync-password-confirm")).toBeHidden();
+});
+
 test("disabled sync still protects local data even when old encrypted cloud data exists", async ({ page }) => {
 	await serveApp(page, { syncEnabled: false });
 	await seed(page, { signedIn: true, chat: true, settings: { onboardingCompleted: "true" } });

--- a/tests/e2e/smoke/app-smoke.spec.ts
+++ b/tests/e2e/smoke/app-smoke.spec.ts
@@ -124,6 +124,7 @@ test("dedicated image models are available only in image selectors", async ({ pa
 	await stubExternalTraffic(page, []);
 	await seedLocalSettings(page);
 	await page.goto("/");
+	await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
 
 	const imageModelIds = await page
 		.locator("#selectedImageModel option")

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -2,11 +2,13 @@ import { expect, test, type Page } from "@playwright/test";
 import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
 
 async function openSubscriptionOverlay(page: Page): Promise<void> {
+	await expect(page.locator("#main-container")).toHaveAttribute("aria-busy", "false");
 	await page.evaluate(async () => {
 		const importModule = new Function("path", "return import(path);") as (path: string) => Promise<any>;
 		const overlayService = await importModule("/services/Overlay.service.ts");
 		overlayService.show("form-subscription");
 	});
+	await expect(page.locator("#form-subscription")).toBeVisible();
 }
 
 test("keeps subscription plan cards within the pricing panel on mobile", async ({ page }) => {

--- a/tests/integration/services/takeout-service.test.ts
+++ b/tests/integration/services/takeout-service.test.ts
@@ -20,6 +20,7 @@ const dbMock = vi.hoisted(() => ({
 }));
 
 const syncServiceMock = vi.hoisted(() => ({
+	fetchSyncPreferences: vi.fn(),
 	isOnlineSyncEnabled: vi.fn(),
 	isSyncActive: vi.fn(),
 	getSyncStatus: vi.fn(),

--- a/vite.e2e.config.mts
+++ b/vite.e2e.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import { fileURLToPath } from "node:url";
+import config from "./vite.config.mjs";
+
+// Production-flag and dev-flag test servers must not overwrite each other's
+// optimized dependencies, or those of a developer's running app.
+export default defineConfig({
+	...config,
+	cacheDir: fileURLToPath(new URL(`./.vite/e2e-${process.env.NODE_ENV ?? "development"}`, import.meta.url))
+});


### PR DESCRIPTION
Visitors to `zodiac.faetalize.dev` are guided to Zozo Chat without losing access to their locally stored data. Users with Cloud Sync enabled, including locked sync, and users without local data redirect quietly to `https://chat.zozo.sh`.

Users with local data see a compact transition with an optional Export data action and a confirmation checkbox. The checkbox alone enables Continue. A successful export opens the unified importer on arrival; continuing without exporting opens the normal app. The transition cannot be dismissed into the old app, and source storage is preserved.

The importer refreshes the destination account's Cloud Sync preference before offering restore destinations and rechecks it before import. An account with Cloud Sync enabled cannot accidentally restore only to local storage, and a failed preference lookup leaves destinations unavailable. Announcements deferred behind an ordinary sheet resume after it closes, while allowing handoffs to other dialogs to finish.

In development, the same flow runs on the current origin, preserving its hostname, protocol, and port. Arrival state prevents redirect loops, and Settings → Debug → Test migration restarts the flow. Debug controls now use Vite's development flag. The transition and takeout sheets also support keyboard focus containment.

## Validation

- Production build and type checking passed
- ESLint and formatting checks passed, including the pre-push lint hook
- All 157 Vitest tests passed with `VITEST_MAX_WORKERS=2`
- All 30 related Playwright tests passed across migration, announcements, and takeout/restore in production and development modes
- The two new Type 3 regressions failed on the original code and passed with the fixes: migration into an existing Cloud Sync account, and resuming an announcement after an ordinary sheet closes
- Cloud-sync coverage uses mocked auth/preference responses with the real app UI and persisted local state; no live backend changes are involved

Closes #231
